### PR TITLE
pilad: do not print output when 410 Gone

### DIFF
--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -154,5 +154,4 @@ func (c *Conn) goneHandler(w http.ResponseWriter, r *http.Request, message strin
 	log.Println(r.Method, r.URL,
 		http.StatusGone, message)
 	w.WriteHeader(http.StatusGone)
-	w.Write([]byte(message))
 }

--- a/pilad/conn_test.go
+++ b/pilad/conn_test.go
@@ -384,16 +384,6 @@ func TestDatabaseHandler_Gone(t *testing.T) {
 	if response.Code != 410 {
 		t.Errorf("response code is %v, expected %v", response.Code, 410)
 	}
-
-	database, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if expected := "database nodb is Gone"; string(database) != expected {
-		t.Errorf("database is %v, expected %v", string(database), expected)
-	}
-
 }
 
 func TestPopStackHandler(t *testing.T) {
@@ -515,17 +505,6 @@ func TestPopStackHandler_NoStackFound(t *testing.T) {
 	if response.Code != 410 {
 		t.Errorf("response code is %v, expected %v", response.Code, 410)
 	}
-
-	message, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(message) != fmt.Sprintf("stack %s is Gone", s.ID.String()) {
-		t.Errorf("message is %s, expected %s",
-			string(message),
-			fmt.Sprintf("stack %s is Gone", s.ID.String()))
-	}
 }
 
 func TestPopStackHandler_NoDatabaseFound(t *testing.T) {
@@ -558,17 +537,6 @@ func TestPopStackHandler_NoDatabaseFound(t *testing.T) {
 
 	if response.Code != 410 {
 		t.Errorf("response code is %v, expected %v", response.Code, 410)
-	}
-
-	message, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(message) != fmt.Sprintf("database %s is Gone", db.ID.String()) {
-		t.Errorf("message is %s, expected %s",
-			string(message),
-			fmt.Sprintf("database %s is Gone", db.ID.String()))
 	}
 }
 
@@ -614,16 +582,5 @@ func TestGoneHandler(t *testing.T) {
 
 	if response.Code != 410 {
 		t.Errorf("response code is %v, expected %v", response.Code, 404)
-	}
-
-	message, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(message) != "database nodb is Gone" {
-		t.Errorf("message is %s, expected %s",
-			string(message),
-			"nodb")
 	}
 }


### PR DESCRIPTION
We consider that error messages should be implicit in the HTTP Code,
so no need to print the output in plain text, which also breaks
JSON parsing tools like `jq`, which aim to be compatible with `pilad`.

Also, the Gone error  message is logged.