### PR TITLE
pilad: set Stack id based on database and stack names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ testv:
 vet:
 	go vet ./...
 
+lint:
+	golint ./...
+
 pilad:	get
 	$(GOPATH)/bin/pilad
 

--- a/pila/database.go
+++ b/pila/database.go
@@ -43,7 +43,7 @@ func NewDatabase(name string) *Database {
 // to the Database.
 func (db *Database) CreateStack(name string) fmt.Stringer {
 	stack := NewStack(name)
-	stack.Database = db
+	stack.SetDatabase(db)
 	db.Stacks[stack.ID] = stack
 	return stack.ID
 }
@@ -55,11 +55,12 @@ func (db *Database) AddStack(stack *Stack) error {
 		return fmt.Errorf("stack %v already added to database %v", stack.Name, stack.Database.Name)
 	}
 
+	stack.SetDatabase(db)
 	if _, ok := db.Stacks[stack.ID]; ok {
+		stack.Database = nil
 		return fmt.Errorf("database %v already contains stack %v", db.Name, stack.Name)
 	}
 
-	stack.Database = db
 	db.Stacks[stack.ID] = stack
 	return nil
 }

--- a/pila/database_test.go
+++ b/pila/database_test.go
@@ -142,7 +142,7 @@ func TestDatabaseStatus(t *testing.T) {
 	s1ID := db.CreateStack("s1")
 	s2ID := db.CreateStack("s2")
 
-	expectedStatus := fmt.Sprintf(`{"id":"8cfa8cb55c92fa403369a13fd12a8e01","name":"db","number_of_stacks":3,"stacks":["%s","%s","%s"]}`, s2ID, s0ID, s1ID)
+	expectedStatus := fmt.Sprintf(`{"id":"8cfa8cb55c92fa403369a13fd12a8e01","name":"db","number_of_stacks":3,"stacks":["%s","%s","%s"]}`, s0ID, s2ID, s1ID)
 	if status := db.Status(); string(status) != expectedStatus {
 		t.Errorf("status is %s, expected %s", string(status), expectedStatus)
 	}

--- a/pila/integration_test.go
+++ b/pila/integration_test.go
@@ -36,7 +36,7 @@ func TestIntegrationBasic(t *testing.T) {
 		t.Errorf("stack2.Peek is %v, expected %v", stack2.Peek(), nil)
 	}
 
-	var ok bool = true
+	var ok = true
 	for ok {
 		var element interface{}
 		element, ok = stack1.Pop()
@@ -59,10 +59,10 @@ func TestIntegrationBasic(t *testing.T) {
 		t.Errorf("stack2.Peek is %v, expected %v", stack2.Peek(), interface{}("foo"))
 	}
 
-	if ok := db.RemoveStack(stack1.ID); !ok {
+	if ok = db.RemoveStack(stack1.ID); !ok {
 		t.Errorf("database %s failed on removing stack %s", db.Name, stack1.Name)
 	}
-	if _, ok := db.Stacks[stack1.ID]; ok {
+	if _, ok = db.Stacks[stack1.ID]; ok {
 		t.Errorf("stack1 %s was found in database %s", stack1.Name, db.Name)
 	}
 

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -50,7 +50,7 @@ func (s *Stack) Pop() (interface{}, bool) {
 	return s.base.Pop()
 }
 
-// Push returns the size of the Stack.
+// Size returns the size of the Stack.
 func (s *Stack) Size() int {
 	return s.base.Size()
 }
@@ -78,7 +78,7 @@ func (s *Stack) SetDatabase(db *Database) {
 	s.SetID()
 }
 
-// SetId recalculates the id of the Stack based on its
+// SetID recalculates the id of the Stack based on its
 // Database name and its own name.
 func (s *Stack) SetID() {
 	if s.Database != nil {

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -33,8 +33,8 @@ type stackStatus struct {
 // an association to any Database.
 func NewStack(name string) *Stack {
 	s := &Stack{}
-	s.ID = uuid.New(name)
 	s.Name = name
+	s.SetId()
 	s.base = stack.NewStack()
 	return s
 }
@@ -69,4 +69,22 @@ func (s *Stack) Status() ([]byte, error) {
 	status.Peek = s.Peek()
 
 	return json.Marshal(status)
+}
+
+// SetDatabase links the Stack with a given Database and
+// recalculates its ID.
+func (s *Stack) SetDatabase(db *Database) {
+	s.Database = db
+	s.SetId()
+}
+
+// SetId recalculates the id of the Stack based on its
+// Database name and its own name.
+func (s *Stack) SetId() {
+	if s.Database != nil {
+		s.ID = uuid.New(s.Database.Name + s.Name)
+		return
+	}
+
+	s.ID = uuid.New(s.Name)
 }

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -34,7 +34,7 @@ type stackStatus struct {
 func NewStack(name string) *Stack {
 	s := &Stack{}
 	s.Name = name
-	s.SetId()
+	s.SetID()
 	s.base = stack.NewStack()
 	return s
 }
@@ -75,12 +75,12 @@ func (s *Stack) Status() ([]byte, error) {
 // recalculates its ID.
 func (s *Stack) SetDatabase(db *Database) {
 	s.Database = db
-	s.SetId()
+	s.SetID()
 }
 
 // SetId recalculates the id of the Stack based on its
 // Database name and its own name.
-func (s *Stack) SetId() {
+func (s *Stack) SetID() {
 	if s.Database != nil {
 		s.ID = uuid.New(s.Database.Name + s.Name)
 		return

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -155,21 +155,21 @@ func TestStackStatus_Error(t *testing.T) {
 	}
 }
 
-func TestStackSetId(t *testing.T) {
+func TestStackSetID(t *testing.T) {
 	db := NewDatabase("test-db")
 
 	stack := NewStack("test-stack")
 	stack.Database = db
-	stack.SetId()
+	stack.SetID()
 
 	if stack.ID.String() != "378c2601e338a49341d9858081452226" {
 		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "378c2601e338a49341d9858081452226")
 	}
 }
 
-func TestStackSetId_NoDatabase(t *testing.T) {
+func TestStackSetID_NoDatabase(t *testing.T) {
 	stack := NewStack("test-stack")
-	stack.SetId()
+	stack.SetID()
 
 	if stack.ID.String() != "2f44edeaa249ba81db20e9ddf000ba65" {
 		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "2f44edeaa249ba81db20e9ddf000ba65")

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -2,6 +2,7 @@ package pila
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -26,6 +27,16 @@ func TestNewStack(t *testing.T) {
 	}
 	if stack.base.Size() != 0 {
 		t.Fatalf("stack.base.Size() is %d, expected %d", stack.base.Size(), 0)
+	}
+}
+
+func TestSetDatabase(t *testing.T) {
+	db := NewDatabase("test-db")
+	stack := NewStack("test-stack")
+	stack.SetDatabase(db)
+
+	if !reflect.DeepEqual(stack.Database, db) {
+		t.Errorf("stack.Database is %v, expected %v", stack.Database, db)
 	}
 }
 
@@ -141,5 +152,26 @@ func TestStackStatus_Error(t *testing.T) {
 
 	if _, err := stack.Status(); err == nil {
 		t.Error("err is nil, expected UnsupportedTypeError")
+	}
+}
+
+func TestStackSetId(t *testing.T) {
+	db := NewDatabase("test-db")
+
+	stack := NewStack("test-stack")
+	stack.Database = db
+	stack.SetId()
+
+	if stack.ID.String() != "378c2601e338a49341d9858081452226" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "378c2601e338a49341d9858081452226")
+	}
+}
+
+func TestStackSetId_NoDatabase(t *testing.T) {
+	stack := NewStack("test-stack")
+	stack.SetId()
+
+	if stack.ID.String() != "2f44edeaa249ba81db20e9ddf000ba65" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "2f44edeaa249ba81db20e9ddf000ba65")
 	}
 }

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -35,7 +35,7 @@ func NewConn() *Conn {
 func (c *Conn) statusHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	log.Println(r.Method, r.URL, http.StatusOK)
-	w.Write(c.Status.ToJson(time.Now()))
+	w.Write(c.Status.ToJSON(time.Now()))
 }
 
 // databasesHandler returns the information of the running databases.

--- a/pilad/port.go
+++ b/pilad/port.go
@@ -2,6 +2,7 @@ package main
 
 import "os"
 
+// PORT represent the default port where pilad will running.
 const PORT = "1205"
 
 // Port returns the port used by pilad.

--- a/pilad/status.go
+++ b/pilad/status.go
@@ -30,16 +30,16 @@ func NewStatus(version string, now time.Time) *Status {
 	return status
 }
 
-// RunningFor returns the time piladb was running in
+// SetRunningFor returns the time piladb was running in
 // seconds given the current time.
 func (s *Status) SetRunningFor(now time.Time) float64 {
 	s.RunningFor = now.Sub(s.StartedAt).Seconds()
 	return s.RunningFor
 }
 
-// ToJson returns the Status into a JSON file in []byte
+// ToJSON returns the Status into a JSON file in []byte
 // format.
-func (s *Status) ToJson(now time.Time) []byte {
+func (s *Status) ToJSON(now time.Time) []byte {
 	_ = s.SetRunningFor(now)
 
 	// Do not check error as the Status type does

--- a/pilad/status_test.go
+++ b/pilad/status_test.go
@@ -46,13 +46,13 @@ func TestStatusSetRunningFor(t *testing.T) {
 
 }
 
-func TestStatusToJson(t *testing.T) {
+func TestStatusToJSON(t *testing.T) {
 	now := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 	status := NewStatus("v1", now)
 	oneHourLater := now.Add(60 * time.Minute)
 	expectedJSON := fmt.Sprintf(`{"status":"OK","version":"v1","host":"%s_%s","pid":%d,"started_at":"2009-11-10T23:00:00Z","running_for":3600}`, runtime.GOOS, runtime.GOARCH, os.Getpid())
 
-	json := status.ToJson(oneHourLater)
+	json := status.ToJSON(oneHourLater)
 	if json == nil {
 		t.Fatal("json is nil")
 	}

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -15,7 +15,7 @@ const seed = "bsa9phh6keet1ogh9ChoeNoK1jae8ro0"
 // https://www.ietf.org/rfc/rfc4122.txt
 type UUID string
 
-// NewUUID creates a new UUID given a string.
+// New creates a new UUID given a string.
 func New(s string) UUID {
 	h := hmac.New(md5.New, []byte(seed))
 	// we ignore errors, since it is not

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// Returns the commit hash of the repository.
+// CommitHash returns the commit hash of the repository.
 func CommitHash() string {
 	cmd := exec.Command("git", []string{"rev-parse", "HEAD"}...)
 


### PR DESCRIPTION
To give real uniqueness to stacks all over the pila,
we recalculate the ID of the stack once this is added
to a database.