### PR TITLE
Decouple model statuses and JSON conversion

### DIFF
--- a/pila/database.go
+++ b/pila/database.go
@@ -20,14 +20,6 @@ type Database struct {
 	Stacks map[fmt.Stringer]*Stack
 }
 
-// databaseStatus represents the status of a Database.
-type databaseStatus struct {
-	ID           string   `json:"id"`
-	Name         string   `json:"name"`
-	NumberStacks int      `json:"number_of_stacks"`
-	Stacks       []string `json:"stacks,omitempty"`
-}
-
 // NewDatabase creates a new Database given a name,
 // without any link to the piladb instance.
 func NewDatabase(name string) *Database {
@@ -79,9 +71,9 @@ func (db *Database) RemoveStack(id fmt.Stringer) bool {
 	return true
 }
 
-// Status returns the status of the Database in json format.
-func (db *Database) Status() []byte {
-	dbs := databaseStatus{}
+// Status returns the status of the Database.
+func (db *Database) Status() DatabaseStatus {
+	dbs := DatabaseStatus{}
 	dbs.ID = db.ID.String()
 	dbs.Name = db.Name
 	dbs.NumberStacks = len(db.Stacks)
@@ -95,9 +87,22 @@ func (db *Database) Status() []byte {
 	ss.Sort()
 	dbs.Stacks = ss
 
+	return dbs
+}
+
+// DatabaseStatus represents the status of a Database.
+type DatabaseStatus struct {
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	NumberStacks int      `json:"number_of_stacks"`
+	Stacks       []string `json:"stacks,omitempty"`
+}
+
+// ToJSON converts a DatabaseStatus into JSON.
+func (databaseStatus DatabaseStatus) ToJSON() []byte {
 	// Do not check error as the Status type does
 	// not contain types that could cause such case.
 	// See http://golang.org/src/encoding/json/encode.go?s=5438:5481#L125
-	b, _ := json.Marshal(dbs)
+	b, _ := json.Marshal(databaseStatus)
 	return b
 }

--- a/pila/database_test.go
+++ b/pila/database_test.go
@@ -1,7 +1,6 @@
 package pila
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -142,17 +141,60 @@ func TestDatabaseStatus(t *testing.T) {
 	s1ID := db.CreateStack("s1")
 	s2ID := db.CreateStack("s2")
 
-	expectedStatus := fmt.Sprintf(`{"id":"8cfa8cb55c92fa403369a13fd12a8e01","name":"db","number_of_stacks":3,"stacks":["%s","%s","%s"]}`, s0ID, s2ID, s1ID)
-	if status := db.Status(); string(status) != expectedStatus {
-		t.Errorf("status is %s, expected %s", string(status), expectedStatus)
+	expectedStatus := DatabaseStatus{
+		ID:           "8cfa8cb55c92fa403369a13fd12a8e01",
+		Name:         "db",
+		NumberStacks: 3,
+		Stacks:       []string{s0ID.String(), s2ID.String(), s1ID.String()},
+	}
+
+	if status := db.Status(); !reflect.DeepEqual(status, expectedStatus) {
+		t.Errorf("status is %v, expected %v", status, expectedStatus)
 	}
 }
 
 func TestDatabaseStatus_Empty(t *testing.T) {
 	db := NewDatabase("db")
 
-	expectedStatus := `{"id":"8cfa8cb55c92fa403369a13fd12a8e01","name":"db","number_of_stacks":0}`
-	if status := db.Status(); string(status) != expectedStatus {
-		t.Errorf("status is %s, expected %s", string(status), expectedStatus)
+	expectedStatus := DatabaseStatus{
+		ID:           "8cfa8cb55c92fa403369a13fd12a8e01",
+		Name:         "db",
+		NumberStacks: 0,
+		Stacks:       []string{},
 	}
+
+	if status := db.Status(); !reflect.DeepEqual(status, expectedStatus) {
+		t.Errorf("status is %#v, expected %#v", status, expectedStatus)
+	}
+}
+
+func TestDatabaseStatusToJSON(t *testing.T) {
+	databaseStatus := DatabaseStatus{
+		ID:           "123456789",
+		Name:         "db",
+		NumberStacks: 3,
+		Stacks:       []string{"stack1", "stack2", "stack3"},
+	}
+
+	expectedToJSON := `{"id":"123456789","name":"db","number_of_stacks":3,"stacks":["stack1","stack2","stack3"]}`
+
+	if toJSON := databaseStatus.ToJSON(); string(toJSON) != expectedToJSON {
+		t.Errorf("toJSON is %s, expected %s", string(toJSON), expectedToJSON)
+	}
+
+}
+
+func TestDatabaseStatusToJSON_Empty(t *testing.T) {
+	databaseStatus := DatabaseStatus{
+		ID:           "123456789",
+		Name:         "db",
+		NumberStacks: 0,
+	}
+
+	expectedToJSON := `{"id":"123456789","name":"db","number_of_stacks":0}`
+
+	if toJSON := databaseStatus.ToJSON(); string(toJSON) != expectedToJSON {
+		t.Errorf("toJSON is %s, expected %s", string(toJSON), expectedToJSON)
+	}
+
 }

--- a/pila/pila.go
+++ b/pila/pila.go
@@ -17,7 +17,7 @@ type Pila struct {
 // pilaStatus contains the status of the Pila instance.
 type pilaStatus struct {
 	NumberDatabases int              `json:"number_of_databases"`
-	Databases       []databaseStatus `json:"databases"`
+	Databases       []DatabaseStatus `json:"databases"`
 }
 
 // NewPila return a blank piladb instance
@@ -81,10 +81,10 @@ func (p *Pila) Status() []byte {
 	ps := pilaStatus{}
 	ps.NumberDatabases = len(p.Databases)
 
-	dbs := make([]databaseStatus, len(p.Databases))
+	dbs := make([]DatabaseStatus, len(p.Databases))
 	n := 0
 	for _, db := range p.Databases {
-		ds := databaseStatus{
+		ds := DatabaseStatus{
 			ID:           db.ID.String(),
 			Name:         db.Name,
 			NumberStacks: len(db.Stacks),

--- a/pila/pila.go
+++ b/pila/pila.go
@@ -14,8 +14,8 @@ type Pila struct {
 	Databases map[fmt.Stringer]*Database
 }
 
-// pilaStatus contains the status of the Pila instance.
-type pilaStatus struct {
+// Status contains the status of the Pila instance.
+type Status struct {
 	NumberDatabases int              `json:"number_of_databases"`
 	Databases       []DatabaseStatus `json:"databases"`
 }
@@ -76,9 +76,9 @@ func (p *Pila) Database(id fmt.Stringer) (*Database, bool) {
 	return db, ok
 }
 
-// Status returns the status of the Pila instance in json format.
-func (p *Pila) Status() []byte {
-	ps := pilaStatus{}
+// Status returns the status of the Pila.
+func (p *Pila) Status() Status {
+	ps := Status{}
 	ps.NumberDatabases = len(p.Databases)
 
 	dbs := make([]DatabaseStatus, len(p.Databases))
@@ -94,9 +94,14 @@ func (p *Pila) Status() []byte {
 	}
 	ps.Databases = dbs
 
+	return ps
+}
+
+// ToJSON converts a Status into JSON.
+func (pilaStatus Status) ToJSON() []byte {
 	// Do not check error as the Status type does
 	// not contain types that could cause such case.
 	// See http://golang.org/src/encoding/json/encode.go?s=5438:5481#L125
-	b, _ := json.Marshal(ps)
+	b, _ := json.Marshal(pilaStatus)
 	return b
 }

--- a/pila/pila_test.go
+++ b/pila/pila_test.go
@@ -13,7 +13,6 @@ func TestNewPila(t *testing.T) {
 	if pila.Databases == nil {
 		t.Error("pila.Databases is nil")
 	}
-
 }
 
 func TestPilaCreateDatabase(t *testing.T) {
@@ -119,24 +118,24 @@ func TestPilaDatabase_False(t *testing.T) {
 	}
 }
 
-func TestPilaStatus(t *testing.T) {
+func TestPilaStatusToJSON(t *testing.T) {
 	pila := NewPila()
 	db0 := NewDatabase("db0")
 	pila.AddDatabase(db0)
 
 	expectedStatus := `{"number_of_databases":1,"databases":[{"id":"714e49277eb730717e413b167b76ef78","name":"db0","number_of_stacks":0}]}`
 
-	if status := pila.Status(); string(status) != expectedStatus {
+	if status := pila.Status().ToJSON(); string(status) != expectedStatus {
 		t.Errorf("status is %s, expected %s", string(status), expectedStatus)
 	}
 }
 
-func TestPilaStatus_Empty(t *testing.T) {
+func TestPilaStatusToJSON_Empty(t *testing.T) {
 	pila := NewPila()
 
 	expectedStatus := `{"number_of_databases":0,"databases":[]}`
 
-	if status := pila.Status(); string(status) != expectedStatus {
+	if status := pila.Status().ToJSON(); string(status) != expectedStatus {
 		t.Errorf("status is %s, expected %s", string(status), expectedStatus)
 	}
 }

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -21,14 +21,6 @@ type Stack struct {
 	base *stack.Stack
 }
 
-// stackStatus represents the status of a Stack.
-type stackStatus struct {
-	ID   string      `json:"id"`
-	Name string      `json:"name"`
-	Peek interface{} `json:"peek"`
-	Size int         `json:"size"`
-}
-
 // NewStack creates a new Stack given a name without
 // an association to any Database.
 func NewStack(name string) *Stack {
@@ -60,17 +52,6 @@ func (s *Stack) Peek() interface{} {
 	return s.base.Peek()
 }
 
-// Status returns the status of the Stack  in json format.
-func (s *Stack) Status() ([]byte, error) {
-	status := stackStatus{}
-	status.ID = s.ID.String()
-	status.Name = s.Name
-	status.Size = s.Size()
-	status.Peek = s.Peek()
-
-	return json.Marshal(status)
-}
-
 // SetDatabase links the Stack with a given Database and
 // recalculates its ID.
 func (s *Stack) SetDatabase(db *Database) {
@@ -87,4 +68,28 @@ func (s *Stack) SetID() {
 	}
 
 	s.ID = uuid.New(s.Name)
+}
+
+// Status returns the status of the Stack  in json format.
+func (s *Stack) Status() StackStatus {
+	status := StackStatus{}
+	status.ID = s.ID.String()
+	status.Name = s.Name
+	status.Size = s.Size()
+	status.Peek = s.Peek()
+
+	return status
+}
+
+// StackStatus represents the status of a Stack.
+type StackStatus struct {
+	ID   string      `json:"id"`
+	Name string      `json:"name"`
+	Peek interface{} `json:"peek"`
+	Size int         `json:"size"`
+}
+
+// ToJSON converts a StackStatus into JSON.
+func (stackStatus StackStatus) ToJSON() ([]byte, error) {
+	return json.Marshal(stackStatus)
 }

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -71,7 +71,7 @@ func (c *Conn) createDatabaseHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	log.Println(r.Method, r.URL, http.StatusCreated)
 	w.WriteHeader(http.StatusCreated)
-	w.Write(db.Status())
+	w.Write(db.Status().ToJSON())
 }
 
 // databaseHandler returns the information of a single database given its ID
@@ -107,7 +107,7 @@ func (c *Conn) databaseHandler(databaseID string) http.Handler {
 
 		w.Header().Set("Content-Type", "application/json")
 		log.Println(r.Method, r.URL, http.StatusOK)
-		w.Write(db.Status())
+		w.Write(db.Status().ToJSON())
 	})
 }
 

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -47,7 +47,7 @@ func (c *Conn) databasesHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	log.Println(r.Method, r.URL, http.StatusOK)
-	w.Write(c.Pila.Status())
+	w.Write(c.Pila.Status().ToJSON())
 }
 
 // createDatabaseHandler creates a Database and returns 201 and the ID and name


### PR DESCRIPTION
This belongs to #7, but also expands #8.

Models (pila, database, stack) have types to define their status, i.e. `TypeStatus`.

Previously, each model had a method called `TypeStatus()`, that converted a model object directly into its status in JSON format. This wasn't the most optimal way, as some status contains others, e.g. database status needs to access all stacks statuses.

Now, there will be separate methods, one for converting the type into a `TypeStatus` type, and another method, `ToJSON`, which belongs to the `*Status` type, that will take care of the type marshaling into JSON.