### PR TITLE
Introduce docs as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs"]
+	path = docs
+	url = git@github.com:oscillatingworks/pilabook.git


### PR DESCRIPTION
Part of #9

Documentation lives in git@github.com:oscillatingworks/pilabook.git and will be present in piladb as a submodule. It is not ready, but submodules makes it easy to keep it up to date with upstream.