### PR TITLE
pkg/stack: add Stacker interface

### DIFF
--- a/pila/stack.go
+++ b/pila/stack.go
@@ -39,7 +39,7 @@ type Stack struct {
 	ReadAt time.Time
 
 	// base represents the Stack data structure
-	base *stack.Stack
+	base stack.Stacker
 }
 
 // NewStack creates a new Stack given a name and a creation date,

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -4,10 +4,11 @@ package stack
 
 import "sync"
 
-// Stack represents the stack data structure as a linked list,
-// containing a pointer to the first Frame as a head and the
-// size of the stack. It also contain a mutex to lock and unlock
-// the access to the stack on I/O.
+// Stack implements the Stacker interface, and represents the stack
+// data structure as a linked list, containing a pointer
+// to the first Frame as a head and the size of the stack.
+// It also contain a mutex to lock and unlock
+// the access to the stack at I/O operations.
 type Stack struct {
 	head *frame
 	size int

--- a/pkg/stack/stacker.go
+++ b/pkg/stack/stacker.go
@@ -1,0 +1,17 @@
+package stack
+
+// Stacker represents an interface that contains all the
+// required methods to implement a Stack that can be
+// used in piladb.
+type Stacker interface {
+	// Push an element into a Stack
+	Push(element interface{})
+	// Pop the topmost element of a stack
+	Pop() (interface{}, bool)
+	// Size returns the size of the Stack
+	Size() int
+	// Peek returns the topmost element of the Stack
+	Peek() interface{}
+	// Flush flushes a Stack
+	Flush()
+}


### PR DESCRIPTION
Part of #32.

This PR introduces a `Stacker` interface, which contains all methods required to implement a Stack.

This means that we can easily introduce another implementations of a Stack into the functionality of piladb. For example, now we're using a Linked List implementation. If we implement a Slice-based Stack, introducing it would just require to change one line of code in the `pila.Stack` type creation.