### PR TITLE
Store always in UTC, show in Local

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ func (c *Config) Get(key string) interface{} {
 func (c *Config) Set(key string, value interface{}) {
 	s, ok := c.Values.Stacks[uuid.New(CONFIG+key)]
 	if !ok {
-		sID := c.Values.CreateStack(key, time.Now())
+		sID := c.Values.CreateStack(key, time.Now().UTC())
 		s, _ = c.Values.Stacks[sID]
 	}
 

--- a/pila/database.go
+++ b/pila/database.go
@@ -96,6 +96,9 @@ func (db *Database) StacksStatus() StacksStatus {
 	var n int
 	ss := make([]StackStatus, len(db.Stacks))
 	for _, s := range db.Stacks {
+		s.CreatedAt = s.CreatedAt.Local()
+		s.UpdatedAt = s.UpdatedAt.Local()
+		s.ReadAt = s.ReadAt.Local()
 		ss[n] = s.Status()
 		n++
 	}

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -125,9 +125,9 @@ func (s *Stack) Status() StackStatus {
 	status.Name = s.Name
 	status.Size = s.Size()
 	status.Peek = s.Peek()
-	status.CreatedAt = s.CreatedAt
-	status.UpdatedAt = s.UpdatedAt
-	status.ReadAt = s.ReadAt
+	status.CreatedAt = s.CreatedAt.Local()
+	status.UpdatedAt = s.UpdatedAt.Local()
+	status.ReadAt = s.ReadAt.Local()
 
 	return status
 }

--- a/pila/stack_status_test.go
+++ b/pila/stack_status_test.go
@@ -21,9 +21,9 @@ func TestStackStatusJSON(t *testing.T) {
 	stack.Update(after)
 
 	expectedStatus := fmt.Sprintf(`{"id":"2f44edeaa249ba81db20e9ddf000ba65","name":"test-stack","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
-		date.Format(now),
-		date.Format(after),
-		date.Format(after))
+		date.Format(now.Local()),
+		date.Format(after.Local()),
+		date.Format(after.Local()))
 	if status, err := stack.Status().ToJSON(); err != nil {
 		t.Fatal(err)
 	} else if string(status) != expectedStatus {
@@ -37,9 +37,9 @@ func TestStackStatusJSON_Empty(t *testing.T) {
 	stack.Update(now)
 
 	expectedStatus := fmt.Sprintf(`{"id":"2f44edeaa249ba81db20e9ddf000ba65","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
-		date.Format(now),
-		date.Format(now),
-		date.Format(now))
+		date.Format(now.Local()),
+		date.Format(now.Local()),
+		date.Format(now.Local()))
 	if status, err := stack.Status().ToJSON(); err != nil {
 		t.Fatal(err)
 	} else if string(status) != expectedStatus {
@@ -93,8 +93,8 @@ func TestStacksStatusJSON(t *testing.T) {
 	}
 
 	expectedStatus := fmt.Sprintf(`{"stacks":[{"id":"a0bfff209889f6f782997a7bd5b3d536","name":"test-stack-1","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"f0d682fdfb3396c6f21e6f4d1d0da1cd","name":"test-stack-2","peek":999,"size":3,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
-		date.Format(now), date.Format(after), date.Format(after),
-		date.Format(now), date.Format(after), date.Format(after))
+		date.Format(now.Local()), date.Format(after.Local()), date.Format(after.Local()),
+		date.Format(now.Local()), date.Format(after.Local()), date.Format(after.Local()))
 	if status, err := stacksStatus.ToJSON(); err != nil {
 		t.Fatal(err)
 	} else if string(status) != expectedStatus {

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -29,7 +29,7 @@ func NewConn() *Conn {
 	conn := &Conn{}
 	conn.Pila = pila.NewPila()
 	conn.Config = config.NewConfig().Default()
-	conn.Status = NewStatus(version.CommitHash(), time.Now(), MemStats())
+	conn.Status = NewStatus(version.CommitHash(), time.Now().UTC(), MemStats())
 	return conn
 }
 
@@ -44,7 +44,7 @@ func (c *Conn) rootHandler(w http.ResponseWriter, r *http.Request) {
 
 // statusHandler writes the piladb status into the response.
 func (c *Conn) statusHandler(w http.ResponseWriter, r *http.Request) {
-	c.Status.Update(time.Now(), MemStats())
+	c.Status.Update(time.Now().UTC(), MemStats())
 
 	w.Header().Set("Content-Type", "application/json")
 	log.Println(r.Method, r.URL, http.StatusOK)
@@ -124,7 +124,7 @@ func (c *Conn) databaseHandler(databaseID string) http.Handler {
 // of them, or create a new one.
 func (c *Conn) stacksHandler(databaseID string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.opDate = time.Now()
+		c.opDate = time.Now().UTC()
 		vars := mux.Vars(r)
 
 		// we override the mux vars to be able to test
@@ -209,7 +209,7 @@ func (c *Conn) createStackHandler(w http.ResponseWriter, r *http.Request, databa
 // the PUSH, POP, PEEK and SIZE methods, and the stack deletion.
 func (c *Conn) stackHandler(params *map[string]string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.opDate = time.Now()
+		c.opDate = time.Now().UTC()
 		vars := mux.Vars(r)
 		// we override the mux vars to be able to test
 		// an arbitrary database and stack ID

--- a/pilad/conn_test.go
+++ b/pilad/conn_test.go
@@ -449,8 +449,8 @@ func TestStacksHandler_GET(t *testing.T) {
 		input, output string
 	}{
 		{"/databases/db/stacks", fmt.Sprintf(`{"stacks":[{"id":"f0306fec639bd57fc2929c8b897b9b37","name":"stack1","peek":"foo","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"dde8f895aea2ffa5546336146b9384e7","name":"stack2","peek":8,"size":2,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
-			date.Format(now1), date.Format(after1), date.Format(after1),
-			date.Format(now2), date.Format(after2), date.Format(after2))},
+			date.Format(now1.Local()), date.Format(after1.Local()), date.Format(after1.Local()),
+			date.Format(now2.Local()), date.Format(after2.Local()), date.Format(after2.Local()))},
 		{"/databases/db/stacks?kv", `{"stacks":{"stack1":"foo","stack2":8}}`},
 	}
 
@@ -530,8 +530,8 @@ func TestStacksHandler_GET_Name(t *testing.T) {
 	}
 
 	if expected := fmt.Sprintf(`{"stacks":[{"id":"f0306fec639bd57fc2929c8b897b9b37","name":"stack1","peek":"bar","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"dde8f895aea2ffa5546336146b9384e7","name":"stack2","peek":"{\"a\":\"b\"}","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
-		date.Format(now1), date.Format(after1), date.Format(after1),
-		date.Format(now2), date.Format(after2), date.Format(after2)); string(stacks) != expected {
+		date.Format(now1.Local()), date.Format(after1.Local()), date.Format(after1.Local()),
+		date.Format(now2.Local()), date.Format(after2.Local()), date.Format(after2.Local())); string(stacks) != expected {
 		t.Errorf("stacks are %s, expected %s", string(stacks), expected)
 	}
 }
@@ -622,7 +622,7 @@ func TestStacksHandler_PUT(t *testing.T) {
 	}
 
 	expectedStack := fmt.Sprintf(`{"id":"bb4dabeeaa6e90108583ddbf49649427","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
-		date.Format(conn.opDate), date.Format(conn.opDate), date.Format(conn.opDate))
+		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 
 	if string(stack) != expectedStack {
 		t.Errorf("stack is %s, expected %s", string(stack), expectedStack)
@@ -663,7 +663,7 @@ func TestStacksHandler_PUT_Name(t *testing.T) {
 	}
 
 	expectedStack := fmt.Sprintf(`{"id":"bb4dabeeaa6e90108583ddbf49649427","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
-		date.Format(conn.opDate), date.Format(conn.opDate), date.Format(conn.opDate))
+		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 
 	if string(stack) != expectedStack {
 		t.Errorf("stack is %s, expected %s", string(stack), expectedStack)
@@ -703,7 +703,7 @@ func TestCreateStackHandler(t *testing.T) {
 	}
 
 	expectedStack := fmt.Sprintf(`{"id":"bb4dabeeaa6e90108583ddbf49649427","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
-		date.Format(conn.opDate), date.Format(conn.opDate), date.Format(conn.opDate))
+		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 	if string(stack) != expectedStack {
 		t.Errorf("stack is %s, expected %s", string(stack), expectedStack)
 	}

--- a/pilad/status.go
+++ b/pilad/status.go
@@ -51,6 +51,7 @@ func (s *Status) ToJSON() []byte {
 	// Do not check error as the Status type does
 	// not contain types that could cause such case.
 	// See http://golang.org/src/encoding/json/encode.go?s=5438:5481#L125
+	s.StartedAt = s.StartedAt.Local()
 	b, _ := json.Marshal(s)
 	return b
 }

--- a/pilad/status_test.go
+++ b/pilad/status_test.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/fern4lvarez/piladb/pkg/date"
 )
 
 func TestNewStatus(t *testing.T) {
@@ -64,7 +66,7 @@ func TestStatusToJSON(t *testing.T) {
 	status := NewStatus("v1", now, nil)
 	oneHourLater := now.Add(60 * time.Minute)
 	mem := runtime.MemStats{Alloc: 0}
-	expectedJSON := fmt.Sprintf(`{"status":"OK","version":"v1","host":"%s_%s","pid":%d,"started_at":"2009-11-10T23:00:00Z","running_for":3600,"number_goroutines":%d,"memory_alloc":"0B"}`, runtime.GOOS, runtime.GOARCH, os.Getpid(), runtime.NumGoroutine())
+	expectedJSON := fmt.Sprintf(`{"status":"OK","version":"v1","host":"%s_%s","pid":%d,"started_at":"%s","running_for":3600,"number_goroutines":%d,"memory_alloc":"0B"}`, runtime.GOOS, runtime.GOARCH, os.Getpid(), date.Format(now.Local()), runtime.NumGoroutine())
 
 	status.Update(oneHourLater, &mem)
 	json := status.ToJSON()


### PR DESCRIPTION
Part of #32 

With this commit, all dates are stored as UTC, and shown as Local. This will keep the dates consistent regardless of where  **piladb** is running.