### PR TITLE
pila: allow publicly to use custom Stack implementation

### DIFF
--- a/pila/database.go
+++ b/pila/database.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/fern4lvarez/piladb/pkg/stack"
 	"github.com/fern4lvarez/piladb/pkg/uuid"
 )
 
@@ -35,7 +36,13 @@ func NewDatabase(name string) *Database {
 // CreateStack creates a new Stack, given a name and a creation date,
 // which is associated to the Database.
 func (db *Database) CreateStack(name string, t time.Time) fmt.Stringer {
-	stack := NewStack(name, t)
+	return db.CreateStackWithBase(name, t, stack.NewStack())
+}
+
+// CreateStackWithBase creates a new Stack, given a name, a creation date,
+// and a stack.Stacker base implementation, which is associated to the Database.
+func (db *Database) CreateStackWithBase(name string, t time.Time, base stack.Stacker) fmt.Stringer {
+	stack := NewStackWithBase(name, t, base)
 	stack.SetDatabase(db)
 	db.Stacks[stack.ID] = stack
 	return stack.ID

--- a/pila/database_test.go
+++ b/pila/database_test.go
@@ -44,6 +44,30 @@ func TestDatabaseCreateStack(t *testing.T) {
 	}
 }
 
+func TestDatabaseCreateStackWithBase(t *testing.T) {
+	db := NewDatabase("test-db")
+	id := db.CreateStackWithBase("test-stack", time.Now(), &TestBaseStack{})
+
+	if id == nil {
+		t.Fatal("stack ID is nil")
+	}
+
+	stack, ok := db.Stacks[id]
+	if !ok {
+		t.Fatal("stack not found in database")
+	}
+	if stack.ID != id {
+		t.Errorf("stack ID is %v, expected %v", stack.ID, id)
+	}
+	if stack.Name != "test-stack" {
+		t.Errorf("stack Name is %s, expected %s", stack.Name, "test-stack")
+	}
+
+	if !reflect.DeepEqual(stack.Database, db) {
+		t.Errorf("stack Database is %v, expected %v", stack.Database, db)
+	}
+}
+
 func TestDatabaseAddStack(t *testing.T) {
 	db := NewDatabase("test-db")
 	stack := NewStack("test-stack", time.Now())

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -43,13 +43,20 @@ type Stack struct {
 }
 
 // NewStack creates a new Stack given a name and a creation date,
-// without an association to any Database.
+// without an association to any Database. It uses the default
+// ./pkg/stack implementation.
 func NewStack(name string, t time.Time) *Stack {
+	return NewStackWithCustomImplementation(name, t, stack.NewStack())
+}
+
+// NewStackWithCustomImplementation creates a new Stack given a name, a creation date,
+// and a stack.Stacker implementation without an association to any Database.
+func NewStackWithCustomImplementation(name string, t time.Time, stack stack.Stacker) *Stack {
 	s := &Stack{}
 	s.Name = name
 	s.SetID()
 	s.CreatedAt = t
-	s.base = stack.NewStack()
+	s.base = stack
 	return s
 }
 

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -46,12 +46,12 @@ type Stack struct {
 // without an association to any Database. It uses the default
 // ./pkg/stack implementation as a base Stack.
 func NewStack(name string, t time.Time) *Stack {
-	return NewStackWithCustomImplementation(name, t, stack.NewStack())
+	return NewStackWithBase(name, t, stack.NewStack())
 }
 
-// NewStackWithCustomImplementation creates a new Stack given a name, a creation date,
+// NewStackWithBase creates a new Stack given a name, a creation date,
 // and a stack.Stacker base implementation, without an association to any Database.
-func NewStackWithCustomImplementation(name string, t time.Time, base stack.Stacker) *Stack {
+func NewStackWithBase(name string, t time.Time, base stack.Stacker) *Stack {
 	s := &Stack{}
 	s.Name = name
 	s.SetID()

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -44,19 +44,19 @@ type Stack struct {
 
 // NewStack creates a new Stack given a name and a creation date,
 // without an association to any Database. It uses the default
-// ./pkg/stack implementation.
+// ./pkg/stack implementation as a base Stack.
 func NewStack(name string, t time.Time) *Stack {
 	return NewStackWithCustomImplementation(name, t, stack.NewStack())
 }
 
 // NewStackWithCustomImplementation creates a new Stack given a name, a creation date,
-// and a stack.Stacker implementation without an association to any Database.
-func NewStackWithCustomImplementation(name string, t time.Time, stack stack.Stacker) *Stack {
+// and a stack.Stacker base implementation, without an association to any Database.
+func NewStackWithCustomImplementation(name string, t time.Time, base stack.Stacker) *Stack {
 	s := &Stack{}
 	s.Name = name
 	s.SetID()
 	s.CreatedAt = t
-	s.base = stack
+	s.base = base
 	return s
 }
 

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -7,13 +7,13 @@ import (
 	"time"
 )
 
-type TestStack struct{}
+type TestBaseStack struct{}
 
-func (s *TestStack) Push(element interface{}) { return }
-func (s *TestStack) Pop() (interface{}, bool) { return nil, false }
-func (s *TestStack) Size() int                { return 0 }
-func (s *TestStack) Peek() interface{}        { return nil }
-func (s *TestStack) Flush()                   { return }
+func (s *TestBaseStack) Push(element interface{}) { return }
+func (s *TestBaseStack) Pop() (interface{}, bool) { return nil, false }
+func (s *TestBaseStack) Size() int                { return 0 }
+func (s *TestBaseStack) Peek() interface{}        { return nil }
+func (s *TestBaseStack) Flush()                   { return }
 
 func TestNewStack(t *testing.T) {
 	now := time.Now()
@@ -45,7 +45,7 @@ func TestNewStack(t *testing.T) {
 
 func TestNewStackWithCustomImplementation(t *testing.T) {
 	now := time.Now()
-	stack := NewStackWithCustomImplementation("test-stack", now, &TestStack{})
+	stack := NewStackWithCustomImplementation("test-stack", now, &TestBaseStack{})
 
 	if stack == nil {
 		t.Fatal("stack is nil")

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -43,9 +43,9 @@ func TestNewStack(t *testing.T) {
 	}
 }
 
-func TestNewStackWithCustomImplementation(t *testing.T) {
+func TestNewStackWithBase(t *testing.T) {
 	now := time.Now()
-	stack := NewStackWithCustomImplementation("test-stack", now, &TestBaseStack{})
+	stack := NewStackWithBase("test-stack", now, &TestBaseStack{})
 
 	if stack == nil {
 		t.Fatal("stack is nil")

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -7,9 +7,45 @@ import (
 	"time"
 )
 
+type TestStack struct{}
+
+func (s *TestStack) Push(element interface{}) { return }
+func (s *TestStack) Pop() (interface{}, bool) { return nil, false }
+func (s *TestStack) Size() int                { return 0 }
+func (s *TestStack) Peek() interface{}        { return nil }
+func (s *TestStack) Flush()                   { return }
+
 func TestNewStack(t *testing.T) {
 	now := time.Now()
 	stack := NewStack("test-stack", now)
+
+	if stack == nil {
+		t.Fatal("stack is nil")
+	}
+
+	if stack.ID.String() != "2f44edeaa249ba81db20e9ddf000ba65" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "2f44edeaa249ba81db20e9ddf000ba65")
+	}
+	if stack.Name != "test-stack" {
+		t.Errorf("stack.Name is %s, expected %s", stack.Name, "test-stack")
+	}
+	if stack.Database != nil {
+		t.Error("stack.Database is not nil")
+	}
+	if stack.CreatedAt != now {
+		t.Errorf("stack.CreatedAt is %v, expected %v", stack.CreatedAt, now)
+	}
+	if stack.base == nil {
+		t.Fatalf("stack.base is nil")
+	}
+	if stack.base.Size() != 0 {
+		t.Fatalf("stack.base.Size() is %d, expected %d", stack.base.Size(), 0)
+	}
+}
+
+func TestNewStackWithCustomImplementation(t *testing.T) {
+	now := time.Now()
+	stack := NewStackWithCustomImplementation("test-stack", now, &TestStack{})
 
 	if stack == nil {
 		t.Fatal("stack is nil")


### PR DESCRIPTION
This commit does not imply API breaking changes, so it can be added in the next
0.1.X release.

Now it is possible to create a `pila.Stack` using a custom
implementation that satisfies the `stack.Stacker` interface, e.g.

```go
type TestStack struct{}

func (s *TestStack) Push(element interface{}) { return }
func (s *TestStack) Pop() (interface{}, bool) { return nil, false }
func (s *TestStack) Size() int                { return 0 }
func (s *TestStack) Peek() interface{}        { return nil }
func (s *TestStack) Flush()                   { return }

stack := pila.NewStackWithCustomImplementation("stack", time.Now(), &TestStack{})
```

It is also possible to create a Stack with a custom base implementation from a Database instance:

```go
id := db.CreateStackWithBase("stack", time.Now(), &TestStack{})
```