### PR TITLE
pilad: Implement `_ping` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - pilad: Add Go Version to Status
+- pilad: Add `/_ping` endpoint.
 
 ## [0.1.1] - 2017-02-20
 

--- a/pilad/README.md
+++ b/pilad/README.md
@@ -17,6 +17,14 @@ Endpoints
 
 Redirects to the `pilad` documentation site and returns `301 Moved Permanently`.
 
+#### GET `/_ping`
+
+Returns `pong` and `200 OK`.
+
+#### HEAD `/_ping`
+
+Returns  headers and `200 OK`.
+
 #### GET `/_status`
 
 Returns `200 OK` and a JSON document with the current piladb status.

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -42,6 +42,12 @@ func (c *Conn) rootHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, redirAddress, http.StatusMovedPermanently)
 }
 
+// pingHandler writes pong.
+func (c *Conn) pingHandler(w http.ResponseWriter, r *http.Request) {
+	log.Println(r.Method, r.URL, http.StatusOK)
+	w.Write([]byte("pong"))
+}
+
 // statusHandler writes the piladb status into the response.
 func (c *Conn) statusHandler(w http.ResponseWriter, r *http.Request) {
 	c.Status.Update(time.Now().UTC(), MemStats())

--- a/pilad/conn_test.go
+++ b/pilad/conn_test.go
@@ -66,6 +66,45 @@ func TestRootHandler(t *testing.T) {
 
 }
 
+func TestPingHandler(t *testing.T) {
+	conn := NewConn()
+	request, err := http.NewRequest("GET", "/_ping", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := httptest.NewRecorder()
+
+	conn.pingHandler(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("response code is %v, expected %v", response.Code, http.StatusOK)
+	}
+
+	pong, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(pong) != "pong" {
+		t.Errorf("pong is %s, expected pong", string(pong))
+	}
+}
+
+func TestPingHandler_HEAD(t *testing.T) {
+	conn := NewConn()
+	request, err := http.NewRequest("HEAD", "/_ping", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := httptest.NewRecorder()
+
+	conn.pingHandler(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Errorf("response code is %v, expected %v", response.Code, http.StatusOK)
+	}
+}
+
 func TestStatusHandler(t *testing.T) {
 	conn := NewConn()
 	request, err := http.NewRequest("GET", "/_status", nil)

--- a/pilad/router.go
+++ b/pilad/router.go
@@ -15,6 +15,11 @@ func Router(conn *Conn) *mux.Router {
 	r.HandleFunc("/", conn.rootHandler).
 		Methods("GET")
 
+	// GET /_ping
+	// HEAD /_ping
+	r.HandleFunc("/_ping", conn.pingHandler).
+		Methods("GET", "HEAD")
+
 	// GET /_status
 	r.HandleFunc("/_status", conn.statusHandler).
 		Methods("GET")


### PR DESCRIPTION
This allows to check health-check of server in a very cheap way.

Should be included in next 0.1.X release.