### PR TITLE
Fix encoding bug when pushing a malformed payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 - pilad: Add Go Version to Status
 - godoc: Extend packages documentation
 
+### Fixed
+- Fix decoding bug when pushing a malformed payload
+
 ## [0.1.1] - 2017-02-20
 
 ### Added

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -1,7 +1,9 @@
 package pila
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -151,6 +153,13 @@ func (element Element) ToJSON() ([]byte, error) {
 
 // Decode decodes json data into an Element.
 func (element *Element) Decode(r io.Reader) error {
-	decoder := json.NewDecoder(r)
+	elementBuffer := new(bytes.Buffer)
+	elementBuffer.ReadFrom(r)
+
+	if !bytes.HasPrefix(elementBuffer.Bytes(), []byte(`{"element"`)) {
+		return errors.New("malformed payload, missing element key?")
+	}
+
+	decoder := json.NewDecoder(elementBuffer)
 	return decoder.Decode(element)
 }

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -294,6 +294,7 @@ func TestElementDecode(t *testing.T) {
 		`{"element":3.14}`,
 		`{"element":"aGVsbG8="}`,
 		`{"element":{"one":1}}`,
+		`{"element":null}`,
 	}
 	expectedElements := []Element{
 		{Value: "foo"},
@@ -301,6 +302,7 @@ func TestElementDecode(t *testing.T) {
 		{Value: 3.14},
 		{Value: "aGVsbG8="},                         // does not decode into []byte
 		{Value: map[string]interface{}{"one": 1.0}}, // decode inner int into float
+		{Value: nil},
 	}
 
 	for i, elementReader := range elementReaders {
@@ -324,6 +326,7 @@ func TestElementDecode_Error(t *testing.T) {
 		` `,
 		`$`,
 		`%{}`,
+		`{"ement":"foo"}`,
 	}
 
 	for _, elementReader := range elementReaders {

--- a/pilad/config_test.go
+++ b/pilad/config_test.go
@@ -222,6 +222,7 @@ func TestConfigKeyHandler_BadRequest(t *testing.T) {
 		{"GET", nil},
 		{"POST", nil},
 		{"POST", bytes.NewBuffer([]byte("{"))},
+		{"POST", bytes.NewBuffer([]byte(`{"elemnt":8}`))},
 	}
 
 	for _, in := range input {

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -33,7 +33,7 @@ func NewConn() *Conn {
 	conn := &Conn{}
 	conn.Pila = pila.NewPila()
 	conn.Config = config.NewConfig()
-	conn.Status = NewStatus(version.Version(version.VERSION), time.Now().UTC(), MemStats())
+	conn.Status = NewStatus(v(), time.Now().UTC(), MemStats())
 	return conn
 }
 


### PR DESCRIPTION
Before this fix, if you tried to `PUSH` an element using some
of the following payloads:

* `{"elent":8}`
* `{"foo":8}`
* `{1:8}`

The server wouldn't complain when parsing them, and would store a
`null` on top of the Stack. Same behavior when trying to set some config
value.

With this fix, we now check that the payload contains the word `element`
as key. Otherwise, we return an error when decoding it, that will become
a `400 Bad Request` in `pilad`.