### PR TITLE
dev: add pila.sh to Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - pilad: Add `/_ping` endpoint
 - godoc: Extend packages documentation
 - vendor: Update dependencies
+- dev: Add pila.sh utilities to Docker image
 
 ### Changed
 - pilad: Show links of interest in `/` endpoint.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ cd $GOPATH/src/github.com/fern4lvarez/piladb
 make pilad
 ```
 
+Clients
+-------
+
+* shell: https://github.com/oscillatingworks/piladb-sh:
+
+  ```
+  source <(curl -s https://raw.githubusercontent.com/oscillatingworks/piladb-sh/master/piladb.sh)
+  piladb_help
+  ```
+
 Development
 -----------
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -9,7 +9,7 @@ FROM golang:latest
 # Install basic development tools.
 RUN \
   apt-get update && \
-  apt-get install -y git vim
+  apt-get install -y git vim httpie
 
 # Install dependencies.
 RUN \
@@ -20,6 +20,10 @@ RUN \
   go get github.com/fern4lvarez/piladb && \
   cd /go/src/github.com/fern4lvarez/piladb && \
   make all
+
+# Install piladb.sh utilities.
+RUN \
+  echo "source <(curl -s https://raw.githubusercontent.com/oscillatingworks/piladb-sh/master/piladb.sh)\nexport PILADB_HOST=127.0.0.1:1205\n" >> /root/.bashrc
 
 # Define mountable directories.
 VOLUME ["/go/src/github.com/fern4lvarez/piladb"]

--- a/dev/README.md
+++ b/dev/README.md
@@ -26,7 +26,7 @@ for an easier usage of the `piladb` image.
 2. Download an [automated build](https://registry.hub.docker.com/u/fern4lvarez/piladb/)
    from the public [Docker Hub Registry](https://registry.hub.docker.com/): `docker pull fern4lvarez/piladb`
 
-   Alternatively, you can build an image from Dockerfile: `docker build -t="fern4lvarez/piladb" github.com/fern4lvarez/piladb`.
+   Alternatively, you can build an image from Dockerfile: `docker build -t="fern4lvarez/piladb" .`.
 
 
 ### Usage


### PR DESCRIPTION
Now that [pila.sh](https://github.com/oscillatingworks/piladb-sh) is a thing, we can add it to the official Docker image.