### PR TITLE
stack: fix data races

### DIFF
--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -62,11 +62,15 @@ func (s *Stack) Pop() (interface{}, bool) {
 
 // Size returns the number of elements that a stack contains.
 func (s *Stack) Size() int {
+	s.mux.Lock()
+	defer s.mux.Unlock()
 	return s.size
 }
 
 // Peek returns the element on top of the stack.
 func (s *Stack) Peek() interface{} {
+	s.mux.Lock()
+	defer s.mux.Unlock()
 	if s.head == nil {
 		return nil
 	}

--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -121,3 +121,12 @@ func TestStackFlush(t *testing.T) {
 		t.Errorf("stack is not empty")
 	}
 }
+
+func TestRace(t *testing.T) {
+	stack := NewStack()
+	go func() { stack.Push(1) }()
+	go func() { stack.Pop() }()
+	go func() { stack.Size() }()
+	go func() { stack.Peek() }()
+	go func() { stack.Flush() }()
+}


### PR DESCRIPTION
In particular, `Peek` could panic, but this doesn't prevent all race conditions (see commit msg).

IMO, the stack should just embed a mutex so that the client can decide whether or not to acquire a lock.