### PR TITLE
New Stack operations #44: isEmpty

### DIFF
--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"time"
+	"encoding/json"
 
 	"github.com/fern4lvarez/piladb/config"
 	"github.com/fern4lvarez/piladb/pila"
@@ -250,6 +251,10 @@ func (c *Conn) stackHandler(params *map[string]string) http.Handler {
 				c.sizeStackHandler(w, r, stack)
 				return
 			}
+			if _, ok := r.Form["is_empty"]; ok {
+				c.isEmptyStackHandler(w, r, stack)
+				return
+			}
 			c.statusStackHandler(w, r, stack)
 			return
 
@@ -310,6 +315,16 @@ func (c *Conn) sizeStackHandler(w http.ResponseWriter, r *http.Request, stack *p
 	// of a stack valid for a JSON encoding.
 	w.Write(stack.SizeToJSON())
 }
+
+// isEmptyStackHandler check if the Stack is empty.
+func (c *Conn) isEmptyStackHandler(w http.ResponseWriter, r *http.Request, stack *pila.Stack) {
+	stack.Read(c.opDate)
+	log.Println(r.Method, r.URL, http.StatusOK, stack.Size(), stack.Size() == 0)
+	w.Header().Set("Content-Type", "application/json")
+    isEmptyResponse, _ := json.Marshal(stack.Size() == 0)
+	w.Write(isEmptyResponse)
+}
+
 
 // pushStackHandler adds an element into a Stack and returns 200 and the element.
 func (c *Conn) pushStackHandler(w http.ResponseWriter, r *http.Request, stack *pila.Stack) {


### PR DESCRIPTION
Hi fern4lvarez,

I am not sure if you are looking for contributors, but I saw your post on r/golang and got interested in the project. I saw issue New Stack operations #44 and decide to take a stab on one of the sub task. If you are cool with having contributors I will be happy to finish some of the other issues too.


Description:

    Added isEmpty functionality to api. Now client can access is_empty rest call to
    determine if the stack associated to the pass in stack id and db id is empty or not.

Testing Methodology:

    Verify the following curl call will return is_empty = false

        curl -XPUT "localhost:1205/databases?name=MY_DATABASE"
        curl -XPUT "localhost:1205/databases/MY_DATABASE/stacks?name=BOOKSHELF"
        curl -XPOST localhost:1205/databases/MY_DATABASE/stacks/BOOKSHELF \
            -d '{"element":{"title":"1984","author":"George Orwell","ISBN":"1595404325","comments":[]}}'
        curl "localhost:1205/databases/MY_DATABASE/stacks/BOOKSHELF?is_empty"

    Verify the following curl call will return is_empty = true

            curl -XPUT "localhost:1205/databases?name=MY_DATABASE"
            curl -XPUT "localhost:1205/databases/MY_DATABASE/stacks?name=BOOKSHELF"
            curl "localhost:1205/databases/MY_DATABASE/stacks/BOOKSHELF?is_empty"

    Verify that empty db or stack will have standard empty response