### PR TITLE
New Stack operations #44: isEmpty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Add option to allow pushing on a Stack when this is full
+- Add `EMPTY` operation
 
 ### Changed
 - pkg/stack: Use RWMutex for concurrent reads

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -78,6 +78,11 @@ func (s *Stack) Size() int {
 	return s.base.Size()
 }
 
+// Empty returns if a stack is empty.
+func (s *Stack) Empty() bool {
+	return s.base.Size() == 0
+}
+
 // Peek returns the element on top of the Stack.
 func (s *Stack) Peek() interface{} {
 	return s.base.Peek()

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -12,6 +12,7 @@ type TestBaseStack struct{}
 func (s *TestBaseStack) Push(element interface{}) { return }
 func (s *TestBaseStack) Pop() (interface{}, bool) { return nil, false }
 func (s *TestBaseStack) Size() int                { return 0 }
+func (s *TestBaseStack) Empty() bool              { return true }
 func (s *TestBaseStack) Peek() interface{}        { return nil }
 func (s *TestBaseStack) Flush()                   { return }
 
@@ -140,6 +141,20 @@ func TestStackSize(t *testing.T) {
 	}
 	if stack.Size() != 10 {
 		t.Errorf("stack.Size() is %d, expected %d", stack.Size(), 10)
+	}
+}
+
+func TestStackEmpty(t *testing.T) {
+	stack := NewStack("test-stack", time.Now())
+	if !stack.Empty() {
+		t.Errorf("stack.Empty() is %d, expected %d", stack.Empty(), true)
+	}
+
+	for i := 0; i < 2; i++ {
+		stack.Push(i)
+	}
+	if stack.Empty() {
+		t.Errorf("stack.Empty() is %d, expected %d", stack.Empty(), false)
 	}
 }
 

--- a/pilad/README.md
+++ b/pilad/README.md
@@ -310,8 +310,8 @@ Returns `410 GONE` if the database or stack do not exist.
 
 > EMPTY operation.
 
-Returns if the stack identify by `$STACK_ID` in database `$DATABASE_ID` is empty, and
-`200 OK`.
+Returns true if the stack identify by `$STACK_ID` in database `$DATABASE_ID` is empty,
+and `200 OK`.
 You can use either the ID or the Name of the stack and database, although the former
 is used as default, the latter as fallback.
 

--- a/pilad/README.md
+++ b/pilad/README.md
@@ -306,6 +306,22 @@ is used as default, the latter as fallback.
 
 Returns `410 GONE` if the database or stack do not exist.
 
+#### GET `/databases/$DATABASE_ID/stacks/$STACK_ID?empty`
+
+> EMPTY operation.
+
+Returns if the stack identify by `$STACK_ID` in database `$DATABASE_ID` is empty, and
+`200 OK`.
+You can use either the ID or the Name of the stack and database, although the former
+is used as default, the latter as fallback.
+
+```json
+200 OK
+false
+```
+
+Returns `410 GONE` if the database or stack do not exist.
+
 #### POST `/databases/$DATABASE_ID/stacks/$STACK_ID` + `{"element":$ELEMENT}`
 
 > PUSH operation.

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"time"
+	"encoding/json"
 
 	"github.com/fern4lvarez/piladb/config"
 	"github.com/fern4lvarez/piladb/pila"
@@ -250,6 +251,10 @@ func (c *Conn) stackHandler(params *map[string]string) http.Handler {
 				c.sizeStackHandler(w, r, stack)
 				return
 			}
+			if _, ok := r.Form["empty"]; ok {
+				c.emptyStackHandler(w, r, stack)
+				return
+			}
 			c.statusStackHandler(w, r, stack)
 			return
 
@@ -309,6 +314,16 @@ func (c *Conn) sizeStackHandler(w http.ResponseWriter, r *http.Request, stack *p
 	// Do not check error as we consider the size
 	// of a stack valid for a JSON encoding.
 	w.Write(stack.SizeToJSON())
+}
+
+// emptyStackHandler check if the Stack is empty.
+func (c *Conn) emptyStackHandler(w http.ResponseWriter, r *http.Request, stack *pila.Stack) {
+	stack.Read(c.opDate)
+	log.Println(r.Method, r.URL, http.StatusOK, stack.Size(), stack.Empty())
+	w.Header().Set("Content-Type", "application/json")
+	emptyHandlerResponse, _ := json.Marshal(stack.Empty())
+
+	w.Write(emptyHandlerResponse)
 }
 
 // pushStackHandler adds an element into a Stack and returns 200 and the element.


### PR DESCRIPTION
Hi fern4lvarez,

This pull request fixes the code reviews from https://github.com/fern4lvarez/piladb/pull/65

1. Pull request merging to dev-0.2 instead of master
2. change handler and api name to empty to conform naming convention
3. Implement Empty function in stack.go
4. Enforce 100% code test coverage.
5. Allow maintainer to edit pull request.

Description:

    Added isEmpty functionality to api. Now client can access is_empty rest call to
    determine if the stack associated to the pass in stack id and db id is empty or not.

Testing Methodology:

    Verify the following curl call will return is_empty = false

        curl -XPUT "localhost:1205/databases?name=MY_DATABASE"
        curl -XPUT "localhost:1205/databases/MY_DATABASE/stacks?name=BOOKSHELF"
        curl -XPOST localhost:1205/databases/MY_DATABASE/stacks/BOOKSHELF \
            -d '{"element":{"title":"1984","author":"George Orwell","ISBN":"1595404325","comments":[]}}'
        curl "localhost:1205/databases/MY_DATABASE/stacks/BOOKSHELF?is_empty"

    Verify the following curl call will return is_empty = true

            curl -XPUT "localhost:1205/databases?name=MY_DATABASE"
            curl -XPUT "localhost:1205/databases/MY_DATABASE/stacks?name=BOOKSHELF"
            curl "localhost:1205/databases/MY_DATABASE/stacks/BOOKSHELF?is_empty"

    Verify that empty db or stack will have standard empty response