### PR TITLE
New Stack operations #44: FULL

### DIFF
--- a/pilad/config.go
+++ b/pilad/config.go
@@ -158,3 +158,12 @@ func (c *Conn) checkMaxStackSize(handler stackHandlerFunc) stackHandlerFunc {
 		handler(w, r, stack)
 	}
 }
+
+// If stack is full return true else return false
+// Default stack maxSize -1 can never be full
+func (c *Conn) isMaxStackSize(stack *pila.Stack) bool {
+	if c.Config.MaxStackSize() == -1 {
+		return false;
+	}
+	return c.Config.MaxStackSize() <= stack.Size()
+}

--- a/pilad/config.go
+++ b/pilad/config.go
@@ -138,10 +138,10 @@ func (c *Conn) configKeyHandler(configKey string) http.Handler {
 }
 
 // checkMaxStackSize checks config value for MaxStackSize and PushWhenFull
-//and execute the wrapped handler if check is validated.
+// and execute the wrapped handler if check is validated.
 func (c *Conn) checkMaxStackSize(handler stackHandlerFunc) stackHandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request, stack *pila.Stack) {
-		if s := c.Config.MaxStackSize(); stack.Size() >= s && s != -1 {
+		if c.isStackFull(stack) {
 			if c.Config.PushWhenFull() {
 				// set internal config value to share with
 				// the next handler that we want to sweep
@@ -159,11 +159,9 @@ func (c *Conn) checkMaxStackSize(handler stackHandlerFunc) stackHandlerFunc {
 	}
 }
 
-// If stack is full return true else return false
-// Default stack maxSize -1 can never be full
-func (c *Conn) isMaxStackSize(stack *pila.Stack) bool {
-	if c.Config.MaxStackSize() == -1 {
-		return false;
-	}
-	return c.Config.MaxStackSize() <= stack.Size()
+// isStackFull returns true if Stack is full based on the Config value,
+// else returns false. Default Stack with size -1 can never be full.
+func (c *Conn) isStackFull(stack *pila.Stack) bool {
+	s := c.Config.MaxStackSize()
+	return stack.Size() >= s && s != -1
 }

--- a/pilad/config_test.go
+++ b/pilad/config_test.go
@@ -430,3 +430,60 @@ func TestCheckMaxStackSize_PushWhenFullWithStackEmpty(t *testing.T) {
 		}
 	}
 }
+
+func TestIsMaxStackSize(t *testing.T) {
+	s := pila.NewStack("stack", time.Now())
+
+	db := pila.NewDatabase("mydb")
+	_ = db.AddStack(s)
+
+	p := pila.NewPila()
+	_ = p.AddDatabase(db)
+
+	conn := NewConn()
+	conn.Pila = p
+
+	conn.Config.Set(vars.PushWhenFull, true)
+
+	element := pila.Element{Value: "test-element"}
+	elementJSON, _ := element.ToJSON()
+
+	inputOutput := []struct {
+		inputSize                int
+		inputPush                bool
+		outputStatus, outputSize int
+		outputPeek               interface{}
+	}{
+		{-1, true, http.StatusOK, 0, nil}, // Test when stack max size is -1 (which signify no max size), isMaxStackSize should always return false
+		{0, true, http.StatusOK, 0, nil}, // Test when stack max size is 0, isMaxStackSize should always return true
+		{1, true, http.StatusOK, 0, nil},
+		{10, true, http.StatusOK, 0, nil},
+	}
+
+	for _, io := range inputOutput {
+		conn.Config.Set(vars.MaxStackSize, io.inputSize)
+		conn.Config.Set(vars.PushWhenFull, io.inputPush)
+		_, err := http.NewRequest("POST",
+			fmt.Sprintf("/databases/%s/stacks/%s",
+				db.ID.String(),
+				s.ID.String()),
+			bytes.NewBuffer(elementJSON))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		isStackFull := conn.isMaxStackSize(s)
+
+		var expectedIsStackFull bool
+
+		if io.inputSize == -1 {
+			expectedIsStackFull = false
+		} else {
+			expectedIsStackFull = s.Size() >= io.inputSize
+		}
+
+		if expectedIsStackFull && !isStackFull{
+			t.Errorf("Stack size is %v, expected isMaxStackSize to return %v but %v is returned", s.Size(), s.Size() >=  io.inputSize, isStackFull)
+		}
+	}
+}

--- a/pilad/config_test.go
+++ b/pilad/config_test.go
@@ -431,7 +431,7 @@ func TestCheckMaxStackSize_PushWhenFullWithStackEmpty(t *testing.T) {
 	}
 }
 
-func TestIsMaxStackSize(t *testing.T) {
+func TestIsStackFull(t *testing.T) {
 	s := pila.NewStack("stack", time.Now())
 
 	db := pila.NewDatabase("mydb")
@@ -455,7 +455,7 @@ func TestIsMaxStackSize(t *testing.T) {
 		outputPeek               interface{}
 	}{
 		{-1, true, http.StatusOK, 0, nil}, // Test when stack max size is -1 (which signify no max size), isMaxStackSize should always return false
-		{0, true, http.StatusOK, 0, nil}, // Test when stack max size is 0, isMaxStackSize should always return true
+		{0, true, http.StatusOK, 0, nil},  // Test when stack max size is 0, isMaxStackSize should always return true
 		{1, true, http.StatusOK, 0, nil},
 		{10, true, http.StatusOK, 0, nil},
 	}
@@ -472,7 +472,7 @@ func TestIsMaxStackSize(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		isStackFull := conn.isMaxStackSize(s)
+		isStackFull := conn.isStackFull(s)
 
 		var expectedIsStackFull bool
 
@@ -482,8 +482,8 @@ func TestIsMaxStackSize(t *testing.T) {
 			expectedIsStackFull = s.Size() >= io.inputSize
 		}
 
-		if expectedIsStackFull && !isStackFull{
-			t.Errorf("Stack size is %v, expected isMaxStackSize to return %v but %v is returned", s.Size(), s.Size() >=  io.inputSize, isStackFull)
+		if expectedIsStackFull && !isStackFull {
+			t.Errorf("Stack size is %v, expected isMaxStackSize to return %v but %v is returned", s.Size(), s.Size() >= io.inputSize, isStackFull)
 		}
 	}
 }

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -255,6 +255,10 @@ func (c *Conn) stackHandler(params *map[string]string) http.Handler {
 				c.emptyStackHandler(w, r, stack)
 				return
 			}
+			if _, ok := r.Form["full"]; ok {
+				c.fullStackHandler(w, r, stack)
+				return
+			}
 			c.statusStackHandler(w, r, stack)
 			return
 
@@ -327,6 +331,18 @@ func (c *Conn) emptyStackHandler(w http.ResponseWriter, r *http.Request, stack *
 	emptyStackHandlerResponse, _ := json.Marshal(stack.Empty())
 
 	w.Write(emptyStackHandlerResponse)
+}
+
+// fullStackHandler checks if the Stack is full.
+func (c *Conn) fullStackHandler(w http.ResponseWriter, r *http.Request, stack *pila.Stack) {
+	stack.Read(c.opDate)
+	isMaxStackSize := c.isMaxStackSize(stack) // caching to prevent re-lock
+	log.Println(r.Method, r.URL, http.StatusOK, isMaxStackSize)
+	w.Header().Set("Content-Type", "application/json")
+	// Do not check error as we consider a boolean
+	// valid for a JSON encoding.
+	fullStackHandlerResponse, _ := json.Marshal(isMaxStackSize)
+	w.Write(fullStackHandlerResponse)
 }
 
 // pushStackHandler adds an element into a Stack and returns 200 and the element.

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -333,15 +333,17 @@ func (c *Conn) emptyStackHandler(w http.ResponseWriter, r *http.Request, stack *
 	w.Write(emptyStackHandlerResponse)
 }
 
-// fullStackHandler checks if the Stack is full.
+// fullStackHandler checks if the Stack is full, based on the configuration value.
 func (c *Conn) fullStackHandler(w http.ResponseWriter, r *http.Request, stack *pila.Stack) {
 	stack.Read(c.opDate)
-	isMaxStackSize := c.isMaxStackSize(stack) // caching to prevent re-lock
-	log.Println(r.Method, r.URL, http.StatusOK, isMaxStackSize)
+	isStackFull := c.isStackFull(stack) // caching to prevent re-lock
+	log.Println(r.Method, r.URL, http.StatusOK, isStackFull)
 	w.Header().Set("Content-Type", "application/json")
+
 	// Do not check error as we consider a boolean
 	// valid for a JSON encoding.
-	fullStackHandlerResponse, _ := json.Marshal(isMaxStackSize)
+	fullStackHandlerResponse, _ := json.Marshal(isStackFull)
+
 	w.Write(fullStackHandlerResponse)
 }
 

--- a/pilad/conn_test.go
+++ b/pilad/conn_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/fern4lvarez/piladb/pila"
 	"github.com/fern4lvarez/piladb/pkg/date"
 	"github.com/fern4lvarez/piladb/pkg/uuid"
+	"github.com/fern4lvarez/piladb/config/vars"
 )
+
 
 func TestNewConn(t *testing.T) {
 	conn := NewConn()
@@ -844,6 +846,7 @@ func TestStackHandler_GET(t *testing.T) {
 
 	expectedSizeJSON := s.SizeToJSON()
 	expectedEmptyResponseJSON := []byte("false")
+	expectedFullResponseJSON := []byte("false")
 
 	inputOutput := []struct {
 		input struct {
@@ -885,6 +888,14 @@ func TestStackHandler_GET(t *testing.T) {
 				response []byte
 				code     int
 			}{expectedEmptyResponseJSON, http.StatusOK},
+		},
+		{struct {
+			database, stack, op string
+		}{db.ID.String(), s.ID.String(), "full"},
+			struct {
+				response []byte
+				code     int
+			}{expectedFullResponseJSON, http.StatusOK},
 		},
 	}
 
@@ -1463,7 +1474,102 @@ func TestEmptyStackHandler_NonEmpty(t *testing.T) {
 	if string(emptyJSON) != expectedEmpty {
 		t.Errorf("is empty response is %v, expected %v", string(emptyJSON), expectedEmpty)
 	}
+}
 
+func TestFullStackHandler_Full(t *testing.T) {
+	s := pila.NewStack("stack", time.Now().UTC())
+
+	db := pila.NewDatabase("db")
+	_ = db.AddStack(s)
+
+	p := pila.NewPila()
+	_ = p.AddDatabase(db)
+
+	conn := NewConn()
+	conn.Pila = p
+	conn.Config.Set(vars.MaxStackSize, 0)
+
+	request, err := http.NewRequest("GET",
+		fmt.Sprintf("/databases/%s/stacks/%s?full",
+			db.ID.String(),
+			s.ID.String()),
+		nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+
+	response := httptest.NewRecorder()
+
+	conn.emptyStackHandler(response, request, s)
+
+	if contentType := response.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Errorf("Content-Type is %v, expected %v", contentType, "application/json")
+	}
+
+	if response.Code != http.StatusOK {
+		t.Errorf("response code is %v, expected %v", response.Code, http.StatusOK)
+	}
+
+	fullJSON, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedFull := "true"
+	if string(fullJSON) != expectedFull {
+		t.Errorf("is full stack handler response is %v, expected %v", string(fullJSON), expectedFull)
+	}
+}
+
+func TestFullStackHandler_NotFull(t *testing.T) {
+	s := pila.NewStack("stack", time.Now().UTC())
+
+	db := pila.NewDatabase("db")
+	_ = db.AddStack(s)
+
+	p := pila.NewPila()
+	_ = p.AddDatabase(db)
+
+	conn := NewConn()
+	conn.Pila = p
+	conn.Config.Set(vars.MaxStackSize, 2)
+
+	s.Push("element")
+
+	request, err := http.NewRequest("GET",
+		fmt.Sprintf("/databases/%s/stacks/%s?full",
+			db.ID.String(),
+			s.ID.String()),
+		nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+
+	response := httptest.NewRecorder()
+
+	conn.emptyStackHandler(response, request, s)
+
+	if contentType := response.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Errorf("Content-Type is %v, expected %v", contentType, "application/json")
+	}
+
+	if response.Code != http.StatusOK {
+		t.Errorf("response code is %v, expected %v", response.Code, http.StatusOK)
+	}
+
+	fullJSON, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedFull := "false"
+	if string(fullJSON) != expectedFull {
+		t.Errorf("is full stack handler response is %v, expected %v", string(fullJSON), expectedFull)
+	}
 }
 
 func TestPushStackHandler(t *testing.T) {

--- a/pilad/conn_test.go
+++ b/pilad/conn_test.go
@@ -10,12 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fern4lvarez/piladb/config/vars"
 	"github.com/fern4lvarez/piladb/pila"
 	"github.com/fern4lvarez/piladb/pkg/date"
 	"github.com/fern4lvarez/piladb/pkg/uuid"
-	"github.com/fern4lvarez/piladb/config/vars"
 )
-
 
 func TestNewConn(t *testing.T) {
 	conn := NewConn()


### PR DESCRIPTION
I am not really sure if putting `isMaxStackSize` in `pilad/config.go` is the best way, feel like check full should be encapsulate in the stack itself.

I am open to suggestion.


    Description:
    
        Add a new rest endpoint FULL which checks if a particular stack is full or not.
    
    Testing Methodology:
    
        Verify the following curl call to full will return full = true
    
            ./bin/pilad -max-stack-size 0
            curl -XPUT "localhost:1205/databases?name=MY_DATABASE"
            curl -XPUT "localhost:1205/databases/MY_DATABASE/stacks?name=BOOKSHELF"
            curl -XPOST localhost:1205/databases/MY_DATABASE/stacks/BOOKSHELF \
                -d '{"element":{"title":"1984","author":"George Orwell","ISBN":"1595404325","comments":[]}}'
            curl "localhost:1205/databases/MY_DATABASE/stacks/BOOKSHELF?full"
    
        Verify the following curl call to full will return full = false
    
            ./bin/pilad -max-stack-size 2
            curl -XPUT "localhost:1205/databases?name=MY_DATABASE"
            curl -XPUT "localhost:1205/databases/MY_DATABASE/stacks?name=BOOKSHELF"
            curl -XPOST localhost:1205/databases/MY_DATABASE/stacks/BOOKSHELF \
                -d '{"element":{"title":"1984","author":"George Orwell","ISBN":"1595404325","comments":[]}}'
            curl "localhost:1205/databases/MY_DATABASE/stacks/BOOKSHELF?full"

