### PR TITLE
pila: add mutex control for Stack dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - pkg/stack: Fix data race conditions on Size and Peek
+- pila: Fix data race conditions on concurrent updates of Stack dates
 
 ## [0.1.2] - 2017-03-05
 

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -240,6 +240,24 @@ func TestStackSizeToJSON(t *testing.T) {
 	}
 }
 
+func TestStackRace(t *testing.T) {
+	stack := NewStack("test-stack", time.Now())
+	go func() { stack.Push(1) }()
+	go func() { stack.Pop() }()
+	go func() { stack.Size() }()
+	go func() { stack.Peek() }()
+	go func() { stack.Flush() }()
+}
+
+func TestStackRace_UpdateRead(t *testing.T) {
+	stack := NewStack("test-stack", time.Now())
+	go func() { stack.Update(time.Now()) }()
+	go func() { stack.Update(time.Now()) }()
+	go func() { stack.Read(time.Now()) }()
+	go func() { stack.Update(time.Now()) }()
+	go func() { stack.Read(time.Now()) }()
+}
+
 func TestElementJSON(t *testing.T) {
 	elements := []Element{
 		{Value: "foo"},


### PR DESCRIPTION
This PR fixes potential race conditions when updating Stack dates concurrently.

**Warning**: These changes might affect performance of Stack operations, but at this point, data integrity is more important than performance.