### PR TITLE
pila: do Database and Stack.ID manipulation thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- pila: Fix data race conditions on Database and Stack ID
+
 ## [0.1.3] - 2017-04-15
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ test:
 testv:
 	go list ./... | grep -v /vendor/ | xargs -L1 go test -v -cover
 
+race:
+	go list ./... | grep -v /vendor/ | xargs -L1 go test -race
+
 vet:
 	go list ./... | grep -v /vendor/ | xargs -L1 go vet
 

--- a/pila/database.go
+++ b/pila/database.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/fern4lvarez/piladb/pkg/stack"
@@ -20,6 +21,9 @@ type Database struct {
 	Pila *Pila
 	// Stacks associated to Database mapped by their ID
 	Stacks map[fmt.Stringer]*Stack
+	// mu provides a Mutex mechanism to avoid data races
+	// when manipulating Databases concurrently.
+	mu sync.Mutex
 }
 
 // NewDatabase creates a new Database given a name,
@@ -42,26 +46,32 @@ func (db *Database) CreateStack(name string, t time.Time) fmt.Stringer {
 // CreateStackWithBase creates a new Stack, given a name, a creation date,
 // and a stack.Stacker base implementation, which is associated to the Database.
 func (db *Database) CreateStackWithBase(name string, t time.Time, base stack.Stacker) fmt.Stringer {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
 	stack := NewStackWithBase(name, t, base)
 	stack.SetDatabase(db)
-	db.Stacks[stack.ID] = stack
-	return stack.ID
+	db.Stacks[stack.UUID()] = stack
+	return stack.UUID()
 }
 
 // AddStack adds a given Stack to the Database, returning
 // an error if any was found.
 func (db *Database) AddStack(stack *Stack) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
 	if stack.Database != nil {
 		return fmt.Errorf("stack %v already added to database %v", stack.Name, stack.Database.Name)
 	}
 
 	stack.SetDatabase(db)
-	if _, ok := db.Stacks[stack.ID]; ok {
+	if _, ok := db.Stacks[stack.UUID()]; ok {
 		stack.Database = nil
 		return fmt.Errorf("database %v already contains stack %v", db.Name, stack.Name)
 	}
 
-	db.Stacks[stack.ID] = stack
+	db.Stacks[stack.UUID()] = stack
 	return nil
 }
 
@@ -69,6 +79,9 @@ func (db *Database) AddStack(stack *Stack) error {
 // returning true if it succeeded. It will return false if the
 // Stack wasn't added to the Database.
 func (db *Database) RemoveStack(id fmt.Stringer) bool {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
 	stack, ok := db.Stacks[id]
 	if !ok {
 		return false

--- a/pila/database.go
+++ b/pila/database.go
@@ -21,7 +21,7 @@ type Database struct {
 	Pila *Pila
 	// Stacks associated to Database mapped by their ID
 	Stacks map[fmt.Stringer]*Stack
-	// mu provides a Mutex mechanism to avoid data races
+	// mu provides a mutex mechanism to avoid data races
 	// when manipulating Databases concurrently.
 	mu sync.Mutex
 }

--- a/pila/database_test.go
+++ b/pila/database_test.go
@@ -299,3 +299,16 @@ func TestDatabaseStacksKV_Empty(t *testing.T) {
 		t.Errorf("key-value is %v, expected %v", kv, expectedKV)
 	}
 }
+
+func TestDatabaseRace(t *testing.T) {
+	db := NewDatabase("db")
+	stack := NewStack("test-stack", time.Now())
+
+	go func() { _ = db.CreateStack("a", time.Now()) }()
+	go func() { _ = db.AddStack(stack) }()
+	go func() { _ = NewDatabase("db2") }()
+	go func() { _ = db.CreateStack("b", time.Now()) }()
+	go func() { _ = db.RemoveStack(stack.UUID()) }()
+	go func() { _ = NewStack("test-stack-2", time.Now()) }()
+	go func() { _ = db.AddStack(stack) }()
+}

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -48,7 +48,7 @@ type Stack struct {
 	// updates in order to avoid race conditions.
 	dateMu sync.Mutex
 
-	// IDMU provides a mute to lock and unlock read and
+	// IDMU provides a mutex to handle concurrent reads and
 	// writes on the Stack ID.
 	IDMu sync.RWMutex
 

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -244,7 +244,9 @@ func TestStackRace(t *testing.T) {
 	stack := NewStack("test-stack", time.Now())
 	go func() { stack.Push(1) }()
 	go func() { stack.Pop() }()
+	go func() { stack.Update(time.Now()) }()
 	go func() { stack.Size() }()
+	go func() { stack.Read(time.Now()) }()
 	go func() { stack.Peek() }()
 	go func() { stack.Flush() }()
 }

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -258,6 +258,14 @@ func TestStackRace_UpdateRead(t *testing.T) {
 	go func() { stack.Read(time.Now()) }()
 }
 
+func TestStackRace_ID(t *testing.T) {
+	stack := NewStack("test-stack", time.Now())
+	go func() { _ = stack.UUID() }()
+	go func() { stack.SetID() }()
+	go func() { _ = stack.UUID() }()
+	go func() { _ = stack.Status() }()
+}
+
 func TestElementJSON(t *testing.T) {
 	elements := []Element{
 		{Value: "foo"},


### PR DESCRIPTION
Motivated by [this converation in Reddit](https://www.reddit.com/r/golang/comments/65jjbe/piladb_013_released/dgazajf/), this PR provides more thread safety to manipulations on Database and Stack types.

The most common case was to add a Stack to a Database, i.e. `db.AddStack(stack)`, and remove the same stack concurrently, i.e. `db.RemoveStack(stack.ID)`. The former adds the Stack to the Database, regenerating the UUID of the stack based on the Stack and Database names, whereas the latter reads the ID of the Stack to remove it. Thus, there's a conflict when editing and consuming this ID. This case, plus others reflected on the tests are fixed now.