### PR TITLE
Add ROTATE stack operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Add `BASE` operation
 - Add `EMPTY` operation
 - Add `FULL` operation
+- Add `ROTATE` operation
 
 ### Fixed
 - pila: Fix data race conditions on Database and Stack ID

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -209,12 +209,23 @@ func (element Element) ToJSON() ([]byte, error) {
 }
 
 // Decode decodes json data into an Element.
+// If the payload is nil, empty, or doesn't
+// follow a {"element":...} pattern, it will
+// return an error.
 func (element *Element) Decode(r io.Reader) error {
+	if r == nil {
+		return errors.New("payload is nil")
+	}
+
 	elementBuffer := new(bytes.Buffer)
 	elementBuffer.ReadFrom(r)
 
+	if len(elementBuffer.Bytes()) == 0 {
+		return errors.New("payload is empty")
+	}
+
 	if !bytes.HasPrefix(elementBuffer.Bytes(), []byte(`{"element"`)) {
-		return errors.New("malformed payload, missing element key?")
+		return errors.New("payload is malformed, missing element key?")
 	}
 
 	decoder := json.NewDecoder(elementBuffer)

--- a/pila/stack.go
+++ b/pila/stack.go
@@ -104,6 +104,12 @@ func (s *Stack) SweepPush(element interface{}) (interface{}, bool) {
 	return s.base.SweepPush(element)
 }
 
+// Rotate moves the bottommost element of the Stack
+// to the top.
+func (s *Stack) Rotate() bool {
+	return s.base.Rotate()
+}
+
 // Size returns the size of the Stack.
 func (s *Stack) Size() int {
 	return s.base.Size()

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -198,6 +198,39 @@ func TestStackSweepPush_False(t *testing.T) {
 	}
 }
 
+func TestStackRotate(t *testing.T) {
+	stack := NewStack("test-stack", time.Now())
+	for i := 0; i < 3; i++ {
+		stack.Push(i)
+	}
+
+	if !stack.Rotate() {
+		t.Errorf("stack.Rotate() is %v, expected %v", false, true)
+	}
+
+	if stack.Peek() != 0 {
+		t.Errorf("stack.Peek() is %v, expected %v", stack.Peek(), 0)
+	}
+	if stack.Size() != 3 {
+		t.Errorf("stack.Size() is %d, expected %d", stack.Size(), 3)
+	}
+}
+
+func TestStackRotate_False(t *testing.T) {
+	stack := NewStack("test-stack", time.Now())
+
+	if stack.Rotate() {
+		t.Errorf("stack.Rotate() is %v, expected %v", true, false)
+	}
+
+	if stack.Peek() != nil {
+		t.Errorf("stack.Peek() is %v, expected %v", stack.Peek(), nil)
+	}
+	if stack.Size() != 0 {
+		t.Errorf("stack.Size() is %d, expected %d", stack.Size(), 0)
+	}
+}
+
 func TestStackSize(t *testing.T) {
 	stack := NewStack("test-stack", time.Now())
 	if stack.Size() != 0 {

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -14,8 +14,8 @@ func (s *TestBaseStack) Pop() (interface{}, bool)                          { ret
 func (s *TestBaseStack) Base(element interface{})                          { return }
 func (s *TestBaseStack) Sweep() (interface{}, bool)                        { return nil, false }
 func (s *TestBaseStack) SweepPush(element interface{}) (interface{}, bool) { return nil, false }
+func (s *TestBaseStack) Rotate() bool                                      { return false }
 func (s *TestBaseStack) Size() int                                         { return 0 }
-func (s *TestBaseStack) Empty() bool                                       { return true }
 func (s *TestBaseStack) Peek() interface{}                                 { return nil }
 func (s *TestBaseStack) Flush()                                            { return }
 

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -489,3 +489,10 @@ func TestElementDecode_Error(t *testing.T) {
 		}
 	}
 }
+
+func TestElementDecode_Nil(t *testing.T) {
+	var element Element
+	if err := element.Decode(nil); err == nil {
+		t.Fatal("err is nil, expected error")
+	}
+}

--- a/pilad/README.md
+++ b/pilad/README.md
@@ -359,7 +359,7 @@ Returns `406 NOT ACCEPTABLE` if the stack is full.
 Returns `410 GONE` if the database or stack do not exist.
 
 Returns `400 BAD REQUEST` if there's an error serializing the element.
-``
+
 #### POST `/databases/$DATABASE_ID/stacks/$STACK_ID?base` + `{"element":$ELEMENT}`
 
 > BASE operation.
@@ -377,6 +377,29 @@ is used as default, the latter as fallback.
 ```
 
 Returns `406 NOT ACCEPTABLE` if the stack is full.
+
+Returns `410 GONE` if the database or stack do not exist.
+
+Returns `400 BAD REQUEST` if there's an error serializing the element.
+
+#### POST `/databases/$DATABASE_ID/stacks/$STACK_ID?rotate`
+
+> ROTATE operation.
+
+Puts the bottommost element on the top of the `$STACK_ID` stack of database `$DATABASE_ID`,
+and returns `200 OK`, and the rotated element. The element next to the former bottommost
+element becomes the new one.
+You can use either the ID or the Name of the stack and database, although the former
+is used as default, the latter as fallback.
+
+```json
+200 OK
+{
+  "element": "this is an element"
+}
+```
+
+Returns `204 NO CONTENT` if the stack is empty.
 
 Returns `410 GONE` if the database or stack do not exist.
 

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -379,13 +379,6 @@ func (c *Conn) rotateStackHandler(w http.ResponseWriter, r *http.Request, stack 
 // addElementStackHandler adds an element into a Stack and returns 200 and the element.
 // It can be as a PUSH or a BASE operation.
 func (c *Conn) addElementStackHandler(w http.ResponseWriter, r *http.Request, stack *pila.Stack) {
-	if r.Body == nil {
-		log.Println(r.Method, r.URL, http.StatusBadRequest,
-			"no element provided")
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
 	var element pila.Element
 	err := element.Decode(r.Body)
 	if err != nil {

--- a/pilad/conn_test.go
+++ b/pilad/conn_test.go
@@ -969,19 +969,22 @@ func TestStackHandler_POST(t *testing.T) {
 	paramss := []map[string]string{
 		{
 			"database_id": db.ID.String(),
-			"stack_id":    s.ID.String(),
+			"stack_id":    s.UUID().String(),
+			"op":          "",
 		},
 		{
 			"database_id": db.Name,
 			"stack_id":    s.Name,
+			"op":          "rotate",
 		},
 	}
 
 	for _, params := range paramss {
 		request, err := http.NewRequest("POST",
-			fmt.Sprintf("/databases/%s/stacks/%s",
+			fmt.Sprintf("/databases/%s/stacks/%s?%s",
 				params["database_id"],
-				params["stack_id"]),
+				params["stack_id"],
+				params["op"]),
 			bytes.NewBuffer(expectedElementJSON))
 		if err != nil {
 			t.Fatal(err)
@@ -1007,7 +1010,7 @@ func TestStackHandler_POST(t *testing.T) {
 		}
 
 		if string(elementJSON) != string(expectedElementJSON) {
-			t.Errorf("pushed element is %v, expected %v", string(elementJSON), string(expectedElementJSON))
+			t.Errorf("element returned is %v, expected %v", string(elementJSON), string(expectedElementJSON))
 		}
 	}
 }
@@ -1568,6 +1571,113 @@ func TestFullStackHandler_NotFull(t *testing.T) {
 	expectedFull := "false"
 	if string(fullJSON) != expectedFull {
 		t.Errorf("is full stack handler response is %v, expected %v", string(fullJSON), expectedFull)
+	}
+}
+
+func TestRotateStackHandler(t *testing.T) {
+	s := pila.NewStack("stack", time.Now().UTC())
+
+	db := pila.NewDatabase("db")
+	_ = db.AddStack(s)
+
+	p := pila.NewPila()
+	_ = p.AddDatabase(db)
+
+	conn := NewConn()
+	conn.Pila = p
+
+	expectedPeekElement := pila.Element{Value: "test-element"}
+	expectedPeekElementJSON, _ := expectedPeekElement.ToJSON()
+
+	expectedBottomElement := pila.Element{Value: 42}
+
+	s.Push(expectedPeekElement.Value)
+	s.Push(expectedBottomElement.Value)
+	s.Push(true)
+
+	request, err := http.NewRequest("POST",
+		fmt.Sprintf("/databases/%s/stacks/%s?rotate",
+			db.ID.String(),
+			s.ID.String()),
+		nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response := httptest.NewRecorder()
+
+	conn.rotateStackHandler(response, request, s)
+
+	if peekElement := db.Stacks[s.ID].Peek(); peekElement != expectedPeekElement.Value {
+		t.Errorf("rotated as peek element is %v, expected %v", peekElement, expectedPeekElement.Value)
+	}
+
+	if bottomElement, ok := db.Stacks[s.ID].Sweep(); !ok {
+		t.Errorf("ok is %v, expected true", ok)
+	} else if bottomElement != expectedBottomElement.Value {
+		t.Errorf("rotated as bottom element is %v, expected %v", bottomElement, expectedBottomElement.Value)
+	}
+	s.Base(expectedBottomElement.Value)
+
+	if contentType := response.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Errorf("Content-Type is %v, expected %v", contentType, "application/json")
+	}
+
+	if response.Code != http.StatusOK {
+		t.Errorf("response code is %v, expected %v", response.Code, http.StatusOK)
+	}
+
+	if size := db.Stacks[s.ID].Size(); size != 3 {
+		t.Errorf("Stack size is %d, expected %d", size, 3)
+	}
+
+	expectedElementJSON, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(expectedPeekElementJSON) != string(expectedElementJSON) {
+		t.Errorf("Peek  element is %v, expected %v", string(expectedPeekElementJSON), string(expectedElementJSON))
+	}
+}
+
+func TestRotateStackHandler_Empty(t *testing.T) {
+	s := pila.NewStack("stack", time.Now().UTC())
+
+	db := pila.NewDatabase("db")
+	_ = db.AddStack(s)
+
+	p := pila.NewPila()
+	_ = p.AddDatabase(db)
+
+	conn := NewConn()
+	conn.Pila = p
+
+	request, err := http.NewRequest("POST",
+		fmt.Sprintf("/databases/%s/stacks/%s?rotate",
+			db.ID.String(),
+			s.ID.String()),
+		nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response := httptest.NewRecorder()
+
+	conn.rotateStackHandler(response, request, s)
+
+	if peekElement := db.Stacks[s.ID].Peek(); peekElement != nil {
+		t.Errorf("rotated as peek element is %v, expected %v", peekElement, nil)
+	}
+
+	if response.Code != http.StatusNoContent {
+		t.Errorf("response code is %v, expected %v", response.Code, http.StatusNoContent)
+	}
+
+	if size := db.Stacks[s.ID].Size(); size != 0 {
+		t.Errorf("Stack size is %d, expected %d", size, 0)
 	}
 }
 

--- a/pilad/conn_test.go
+++ b/pilad/conn_test.go
@@ -973,6 +973,26 @@ func TestStackHandler_POST(t *testing.T) {
 			"op":          "",
 		},
 		{
+			"database_id": db.ID.String(),
+			"stack_id":    s.UUID().String(),
+			"op":          "base",
+		},
+		{
+			"database_id": db.ID.String(),
+			"stack_id":    s.UUID().String(),
+			"op":          "rotate",
+		},
+		{
+			"database_id": db.Name,
+			"stack_id":    s.Name,
+			"op":          "",
+		},
+		{
+			"database_id": db.Name,
+			"stack_id":    s.Name,
+			"op":          "base",
+		},
+		{
 			"database_id": db.Name,
 			"stack_id":    s.Name,
 			"op":          "rotate",

--- a/pilad/router.go
+++ b/pilad/router.go
@@ -54,6 +54,7 @@ func Router(conn *Conn) *mux.Router {
 	// GET /databases/$DATABASE_ID/stacks/$STACK_ID?full
 	// POST /databases/$DATABASE_ID/stacks/$STACK_ID + {element: value}
 	// POST /databases/$DATABASE_ID/stacks/$STACK_ID?base + {element: value}
+	// POST /databases/$DATABASE_ID/stacks/$STACK_ID?rotate
 	// DELETE /databases/$DATABASE_ID/stacks/$STACK_ID
 	// DELETE /databases/$DATABASE_ID/stacks/$STACK_ID?flush
 	// DELETE /databases/$DATABASE_ID/stacks/$STACK_ID?full

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -198,6 +198,37 @@ func (s *Stack) SweepPush(element interface{}) (interface{}, bool) {
 	return swept, true
 }
 
+// Rotate puts the bottommost element of the Stack into the top,
+// as an action of rotating the contents. Return false if the Stack
+// is empty.
+func (s *Stack) Rotate() bool {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	if s.size == 0 {
+		return false
+	}
+
+	if s.size == 1 {
+		return true
+	}
+
+	// build new head
+	head := s.tail
+	head.down = s.head
+
+	// set new tail
+	s.tail = s.tail.up
+	s.tail.down = nil
+
+	// set new head
+	s.head = head
+	s.head.down.up = head
+	s.head.up = nil
+
+	return true
+}
+
 // Size returns the number of elements that a stack contains.
 func (s *Stack) Size() int {
 	s.mux.RLock()

--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -561,6 +561,140 @@ func TestStackSweepPush_False(t *testing.T) {
 	}
 }
 
+func TestStackRotate(t *testing.T) {
+	stack := NewStack()
+	stack.Push("test")
+	stack.Push(true)
+	stack.Push(8)
+
+	ok := stack.Rotate()
+	if !ok {
+		t.Errorf("stack.Rotate() not ok")
+	}
+	if stack.tail == nil {
+		t.Fatal("stack.tail is nil")
+	}
+	if stack.tail.data != true {
+		t.Errorf("stack.tail data is %v, expected %v", stack.tail.data, true)
+	}
+	if stack.tail.down != nil {
+		t.Errorf("stack.tail.down is %v, expected nil", stack.tail.down)
+	}
+	if stack.tail.up.data != 8 {
+		t.Errorf("stack.tail.up is %v, expected %v", stack.tail.up.data, 8)
+	}
+	if stack.head == nil {
+		t.Fatal("stack.head is nil")
+	}
+	if stack.head.data != "test" {
+		t.Errorf("stack.head.data is %v, expected %v", stack.head.data, "test")
+	}
+	if stack.head.down.data != 8 {
+		t.Errorf("stack.head.down is %v, expected %v", stack.head.down.data, 8)
+	}
+	if stack.head.up != nil {
+		t.Errorf("stack.head.up is %v, expected nil", stack.head.up)
+	}
+	if stack.size != 3 {
+		t.Errorf("stack.size is %v, expected %v", stack.size, 3)
+	}
+}
+
+func TestStackRotate_Complete(t *testing.T) {
+	stack := NewStack()
+	stack.Push("test")
+	stack.Push(true)
+	stack.Push(8)
+
+	for i := 0; i < 3; i++ {
+		if ok := stack.Rotate(); !ok {
+			t.Errorf("stack.Rotate() not ok")
+		}
+	}
+	if stack.tail == nil {
+		t.Fatal("stack.tail is nil")
+	}
+	if stack.tail.data != "test" {
+		t.Errorf("stack.tail data is %v, expected %v", stack.tail.data, "test")
+	}
+	if stack.tail.down != nil {
+		t.Errorf("stack.tail.down is %v, expected nil", stack.tail.down)
+	}
+	if stack.tail.up.data != true {
+		t.Errorf("stack.tail.up is %v, expected %v", stack.tail.up.data, true)
+	}
+	if stack.head == nil {
+		t.Fatal("stack.head is nil")
+	}
+	if stack.head.data != 8 {
+		t.Errorf("stack.head.data is %v, expected %v", stack.head.data, 8)
+	}
+	if stack.head.down.data != true {
+		t.Errorf("stack.head.down is %v, expected %v", stack.head.down.data, true)
+	}
+	if stack.head.up != nil {
+		t.Errorf("stack.head.up is %v, expected nil", stack.head.up)
+	}
+	if stack.size != 3 {
+		t.Errorf("stack.size is %v, expected %v", stack.size, 3)
+	}
+}
+
+func TestStackRotate_OneElement(t *testing.T) {
+	stack := NewStack()
+	stack.Push("test")
+
+	ok := stack.Rotate()
+	if !ok {
+		t.Errorf("stack.Rotate() not ok")
+	}
+	if stack.tail == nil {
+		t.Fatal("stack.tail is nil")
+	}
+	if stack.tail.data != "test" {
+		t.Errorf("stack.tail data is %v, expected %v", stack.tail.data, "test")
+	}
+	if stack.tail.down != nil {
+		t.Errorf("stack.tail.down is %v, expected nil", stack.tail.down)
+	}
+	if stack.tail.up != nil {
+		t.Errorf("stack.tail.up is %v, expected nil", stack.tail.up)
+	}
+	if stack.head == nil {
+		t.Fatal("stack.head is nil")
+	}
+	if stack.head.data != "test" {
+		t.Errorf("stack.head.data is %v, expected %v", stack.head.data, "test")
+	}
+	if stack.head.down != nil {
+		t.Errorf("stack.head.down is %v, expected nil", stack.head.down)
+	}
+	if stack.head.up != nil {
+		t.Errorf("stack.head.up is %v, expected nil", stack.head.up)
+	}
+	if stack.size != 1 {
+		t.Errorf("stack.size is %v, expected %v", stack.size, 1)
+	}
+}
+
+func TestStackRotate_Empty(t *testing.T) {
+	stack := NewStack()
+
+	ok := stack.Rotate()
+	if ok {
+		t.Errorf("stack.Rotate() is ok")
+	}
+	if stack.tail != nil {
+		t.Errorf("stack.tail is %v, expected nil", stack.tail)
+	}
+	if stack.head != nil {
+		t.Errorf("stack.tail is %v, expected nil", stack.head)
+	}
+	if stack.size != 0 {
+		t.Errorf("stack.size is %v, expected %v", stack.size, 0)
+	}
+}
+
 func TestStackSize(t *testing.T) {
 	stack := NewStack()
 	if stack.Size() != 0 {

--- a/pkg/stack/stacker.go
+++ b/pkg/stack/stacker.go
@@ -6,15 +6,17 @@ package stack
 type Stacker interface {
 	// Push an element into a Stack
 	Push(element interface{})
-	// Pop the topmost element of a stack
+	// Pop the topmost element of a Stack
 	Pop() (interface{}, bool)
 	// Base bases a new element at the bottom of the stack
 	Base(element interface{})
 	// Sweep the bottommost element of a stack
 	Sweep() (interface{}, bool)
-	// SweepPush sweeps the bottommost element of a stack
+	// SweepPush sweeps the bottommost element of a Stack
 	// and pushes another on top
 	SweepPush(element interface{}) (interface{}, bool)
+	// Rotate the bottommost element of a Stack to the top
+	Rotate() bool
 	// Size returns the size of the Stack
 	Size() int
 	// Peek returns the topmost element of the Stack


### PR DESCRIPTION
Part of #44

The ROTATE operation will move the bottommost element of a Stack to the top, becoming this the new peak. If the Stack is empty, it won't do anything.