### PR TITLE
Use UUID Version 5

### DIFF
--- a/pila/database_test.go
+++ b/pila/database_test.go
@@ -9,8 +9,8 @@ import (
 func TestNewDatabase(t *testing.T) {
 	db := NewDatabase("test-1")
 
-	if db.ID.String() != "2b87e5d8b7d3d853514c8d0801fbcf46" {
-		t.Errorf("db.ID is %v, expected %v", db.ID, "2b87e5d8b7d3d853514c8d0801fbcf46")
+	if db.ID.String() != "6d704898-7e0a-5d25-8588-8f88378757d4" {
+		t.Errorf("db.ID is %v, expected %v", db.ID, "6d704898-7e0a-5d25-8588-8f88378757d4")
 	}
 	if db.Name != "test-1" {
 		t.Errorf("db.Name is %v, expected %v", db.Name, "test-1")
@@ -167,10 +167,10 @@ func TestDatabaseStatus(t *testing.T) {
 	s2ID := db.CreateStack("s2", time.Now())
 
 	expectedStatus := DatabaseStatus{
-		ID:           "8cfa8cb55c92fa403369a13fd12a8e01",
+		ID:           "4f772915-1233-5679-845f-b4fe78c3115d",
 		Name:         "db",
 		NumberStacks: 3,
-		Stacks:       []string{s0ID.String(), s2ID.String(), s1ID.String()},
+		Stacks:       []string{s2ID.String(), s1ID.String(), s0ID.String()},
 	}
 
 	if status := db.Status(); !reflect.DeepEqual(status, expectedStatus) {
@@ -182,7 +182,7 @@ func TestDatabaseStatus_Empty(t *testing.T) {
 	db := NewDatabase("db")
 
 	expectedStatus := DatabaseStatus{
-		ID:           "8cfa8cb55c92fa403369a13fd12a8e01",
+		ID:           "4f772915-1233-5679-845f-b4fe78c3115d",
 		Name:         "db",
 		NumberStacks: 0,
 		Stacks:       []string{},

--- a/pila/pila_test.go
+++ b/pila/pila_test.go
@@ -123,7 +123,7 @@ func TestPilaStatusToJSON(t *testing.T) {
 	db0 := NewDatabase("db0")
 	pila.AddDatabase(db0)
 
-	expectedStatus := `{"number_of_databases":1,"databases":[{"id":"714e49277eb730717e413b167b76ef78","name":"db0","number_of_stacks":0}]}`
+	expectedStatus := `{"number_of_databases":1,"databases":[{"id":"23fdcd2d-6391-5530-b3bc-0123ce2be69e","name":"db0","number_of_stacks":0}]}`
 
 	if status := pila.Status().ToJSON(); string(status) != expectedStatus {
 		t.Errorf("status is %s, expected %s", string(status), expectedStatus)

--- a/pila/stack_status_test.go
+++ b/pila/stack_status_test.go
@@ -20,7 +20,7 @@ func TestStackStatusJSON(t *testing.T) {
 	stack.Push([]byte("test"))
 	stack.Update(after)
 
-	expectedStatus := fmt.Sprintf(`{"id":"2f44edeaa249ba81db20e9ddf000ba65","name":"test-stack","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStatus := fmt.Sprintf(`{"id":"de009dba-4ad2-50e5-b020-e9d4c26d7a33","name":"test-stack","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(now.Local()),
 		date.Format(after.Local()),
 		date.Format(after.Local()))
@@ -36,7 +36,7 @@ func TestStackStatusJSON_Empty(t *testing.T) {
 	stack := NewStack("test-stack", now)
 	stack.Update(now)
 
-	expectedStatus := fmt.Sprintf(`{"id":"2f44edeaa249ba81db20e9ddf000ba65","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStatus := fmt.Sprintf(`{"id":"de009dba-4ad2-50e5-b020-e9d4c26d7a33","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(now.Local()),
 		date.Format(now.Local()),
 		date.Format(now.Local()))
@@ -92,7 +92,7 @@ func TestStacksStatusJSON(t *testing.T) {
 		Stacks: []StackStatus{stack1.Status(), stack2.Status()},
 	}
 
-	expectedStatus := fmt.Sprintf(`{"stacks":[{"id":"a0bfff209889f6f782997a7bd5b3d536","name":"test-stack-1","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"f0d682fdfb3396c6f21e6f4d1d0da1cd","name":"test-stack-2","peek":999,"size":3,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
+	expectedStatus := fmt.Sprintf(`{"stacks":[{"id":"52d45e8a-2535-51f3-be38-db3cbbde1805","name":"test-stack-1","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"0fe738cb-d8a1-5871-b6d7-8fe51d957582","name":"test-stack-2","peek":999,"size":3,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
 		date.Format(now.Local()), date.Format(after.Local()), date.Format(after.Local()),
 		date.Format(now.Local()), date.Format(after.Local()), date.Format(after.Local()))
 	if status, err := stacksStatus.ToJSON(); err != nil {

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -27,8 +27,8 @@ func TestNewStack(t *testing.T) {
 		t.Fatal("stack is nil")
 	}
 
-	if stack.ID.String() != "2f44edeaa249ba81db20e9ddf000ba65" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "2f44edeaa249ba81db20e9ddf000ba65")
+	if stack.ID.String() != "de009dba-4ad2-50e5-b020-e9d4c26d7a33" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "de009dba-4ad2-50e5-b020-e9d4c26d7a33")
 	}
 	if stack.Name != "test-stack" {
 		t.Errorf("stack.Name is %s, expected %s", stack.Name, "test-stack")
@@ -55,8 +55,8 @@ func TestNewStackWithBase(t *testing.T) {
 		t.Fatal("stack is nil")
 	}
 
-	if stack.ID.String() != "2f44edeaa249ba81db20e9ddf000ba65" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "2f44edeaa249ba81db20e9ddf000ba65")
+	if stack.ID.String() != "de009dba-4ad2-50e5-b020-e9d4c26d7a33" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "de009dba-4ad2-50e5-b020-e9d4c26d7a33")
 	}
 	if stack.Name != "test-stack" {
 		t.Errorf("stack.Name is %s, expected %s", stack.Name, "test-stack")
@@ -337,8 +337,8 @@ func TestStackSetID(t *testing.T) {
 	stack.Database = db
 	stack.SetID()
 
-	if stack.ID.String() != "378c2601e338a49341d9858081452226" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "378c2601e338a49341d9858081452226")
+	if stack.ID.String() != "7ea60de7-88f9-5163-8cc1-ed77ba1ee534" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "7ea60de7-88f9-5163-8cc1-ed77ba1ee534")
 	}
 }
 
@@ -346,8 +346,8 @@ func TestStackSetID_NoDatabase(t *testing.T) {
 	stack := NewStack("test-stack", time.Now())
 	stack.SetID()
 
-	if stack.ID.String() != "2f44edeaa249ba81db20e9ddf000ba65" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "2f44edeaa249ba81db20e9ddf000ba65")
+	if stack.ID.String() != "de009dba-4ad2-50e5-b020-e9d4c26d7a33" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "de009dba-4ad2-50e5-b020-e9d4c26d7a33")
 	}
 }
 

--- a/pilad/README.md
+++ b/pilad/README.md
@@ -182,7 +182,7 @@ is used as default, the latter as fallback.
 {
   "stacks" : [
     {
-      "id":"f0306fec639bd57fc2929c8b897b9b37",
+      "id":"e73d14e1-dd73-5643-a6dc-a1b2d985c122",
       "name":"stack1",
       "peek":"foo",
       "size":1,
@@ -191,7 +191,7 @@ is used as default, the latter as fallback.
       "read_at":"2016-12-08T18:21:270.813642732+01:00"
     },
     {
-      "id":"dde8f895aea2ffa5546336146b9384e7",
+      "id":"b5f3f218-728d-5d8e-ae5f-56a8a31e970c",
       "name":"stack2",
       "peek":8,
       "size":2,

--- a/pilad/conn_test.go
+++ b/pilad/conn_test.go
@@ -164,7 +164,7 @@ func TestDatabasesHandler_GET(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := `{"number_of_databases":1,"databases":[{"id":"8cfa8cb55c92fa403369a13fd12a8e01","name":"db","number_of_stacks":0}]}`; string(databases) != expected {
+	if expected := `{"number_of_databases":1,"databases":[{"id":"4f772915-1233-5679-845f-b4fe78c3115d","name":"db","number_of_stacks":0}]}`; string(databases) != expected {
 		t.Errorf("databases are %s, expected %s", string(databases), expected)
 	}
 }
@@ -237,8 +237,8 @@ func TestCreateDatabaseHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if string(databases) != `{"id":"8cfa8cb55c92fa403369a13fd12a8e01","name":"db","number_of_stacks":0}` {
-		t.Errorf("databases are %s, expected %s", string(databases), `{"id":"8cfa8cb55c92fa403369a13fd12a8e01","name":"db","number_of_stacks":0}`)
+	if string(databases) != `{"id":"4f772915-1233-5679-845f-b4fe78c3115d","name":"db","number_of_stacks":0}` {
+		t.Errorf("databases are %s, expected %s", string(databases), `{"id":"4f772915-1233-5679-845f-b4fe78c3115d","name":"db","number_of_stacks":0}`)
 	}
 }
 
@@ -324,7 +324,7 @@ func TestDatabaseHandler_GET(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := `{"id":"c13cec0e70876381c78c616ee2d809eb","name":"mydb","number_of_stacks":1,"stacks":["b92f53fa3884305ef798fd8c5d7609ad"]}`; string(database) != expected {
+	if expected := `{"id":"b816d2fd-5a22-5d94-804c-701c4cefae29","name":"mydb","number_of_stacks":1,"stacks":["98256b87-69a5-56ad-9821-72f6d5076aba"]}`; string(database) != expected {
 		t.Errorf("database is %v, expected %v", string(database), expected)
 	}
 }
@@ -368,7 +368,7 @@ func TestDatabaseHandler_GET_Name(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := `{"id":"c13cec0e70876381c78c616ee2d809eb","name":"mydb","number_of_stacks":1,"stacks":["b92f53fa3884305ef798fd8c5d7609ad"]}`; string(database) != expected {
+	if expected := `{"id":"b816d2fd-5a22-5d94-804c-701c4cefae29","name":"mydb","number_of_stacks":1,"stacks":["98256b87-69a5-56ad-9821-72f6d5076aba"]}`; string(database) != expected {
 		t.Errorf("database is %v, expected %v", string(database), expected)
 	}
 }
@@ -488,7 +488,7 @@ func TestStacksHandler_GET(t *testing.T) {
 	inputOutput := []struct {
 		input, output string
 	}{
-		{"/databases/db/stacks", fmt.Sprintf(`{"stacks":[{"id":"f0306fec639bd57fc2929c8b897b9b37","name":"stack1","peek":"foo","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"dde8f895aea2ffa5546336146b9384e7","name":"stack2","peek":8,"size":2,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
+		{"/databases/db/stacks", fmt.Sprintf(`{"stacks":[{"id":"e73d14e1-dd73-5643-a6dc-a1b2d985c122","name":"stack1","peek":"foo","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"b5f3f218-728d-5d8e-ae5f-56a8a31e970c","name":"stack2","peek":8,"size":2,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
 			date.Format(now1.Local()), date.Format(after1.Local()), date.Format(after1.Local()),
 			date.Format(now2.Local()), date.Format(after2.Local()), date.Format(after2.Local()))},
 		{"/databases/db/stacks?kv", `{"stacks":{"stack1":"foo","stack2":8}}`},
@@ -569,7 +569,7 @@ func TestStacksHandler_GET_Name(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := fmt.Sprintf(`{"stacks":[{"id":"f0306fec639bd57fc2929c8b897b9b37","name":"stack1","peek":"bar","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"dde8f895aea2ffa5546336146b9384e7","name":"stack2","peek":"{\"a\":\"b\"}","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
+	if expected := fmt.Sprintf(`{"stacks":[{"id":"e73d14e1-dd73-5643-a6dc-a1b2d985c122","name":"stack1","peek":"bar","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"b5f3f218-728d-5d8e-ae5f-56a8a31e970c","name":"stack2","peek":"{\"a\":\"b\"}","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
 		date.Format(now1.Local()), date.Format(after1.Local()), date.Format(after1.Local()),
 		date.Format(now2.Local()), date.Format(after2.Local()), date.Format(after2.Local())); string(stacks) != expected {
 		t.Errorf("stacks are %s, expected %s", string(stacks), expected)
@@ -661,7 +661,7 @@ func TestStacksHandler_PUT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedStack := fmt.Sprintf(`{"id":"bb4dabeeaa6e90108583ddbf49649427","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStack := fmt.Sprintf(`{"id":"8709893b-a89f-5b9b-85da-370448c7e856","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 
 	if string(stack) != expectedStack {
@@ -702,7 +702,7 @@ func TestStacksHandler_PUT_Name(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedStack := fmt.Sprintf(`{"id":"bb4dabeeaa6e90108583ddbf49649427","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStack := fmt.Sprintf(`{"id":"8709893b-a89f-5b9b-85da-370448c7e856","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 
 	if string(stack) != expectedStack {
@@ -742,7 +742,7 @@ func TestCreateStackHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedStack := fmt.Sprintf(`{"id":"bb4dabeeaa6e90108583ddbf49649427","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStack := fmt.Sprintf(`{"id":"8709893b-a89f-5b9b-85da-370448c7e856","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 	if string(stack) != expectedStack {
 		t.Errorf("stack is %s, expected %s", string(stack), expectedStack)

--- a/pkg/uuid/README.md
+++ b/pkg/uuid/README.md
@@ -1,6 +1,6 @@
 uuid
 ====
 
-Special thanks to [dynport](http://github.com/dynport) for influencing on this UUID
-implementation.
+It uses UUID Version 5, based on SHA-1 hashing (RFC 4122), implemented by @satori.
 
+See https://github.com/satori/go.uuid

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -1,12 +1,9 @@
-// Package uuid provides the UUID type and
+// Package uuid provides the UUID type Version 5,
+// based on SHA-1 hashing (RFC 4122), and
 // helper functions.
 package uuid
 
-import (
-	"crypto/hmac"
-	"crypto/md5"
-	"fmt"
-)
+import gouuid "github.com/satori/go.uuid"
 
 // seed must never change
 const seed = "bsa9phh6keet1ogh9ChoeNoK1jae8ro0"
@@ -17,11 +14,11 @@ type UUID string
 
 // New creates a new UUID given a string.
 func New(s string) UUID {
-	h := hmac.New(md5.New, []byte(seed))
-	// we ignore errors, since it is not
-	// testable
-	_, _ = h.Write([]byte(s))
-	return UUID(fmt.Sprintf("%x", h.Sum(nil)))
+	// we ignore errors, since we consider
+	// our seed valid to be converted to UUID
+	seedUUID, _ := gouuid.FromString(seed)
+	u := gouuid.NewV5(seedUUID, s)
+	return UUID(u.String())
 }
 
 // String returns a string representation of the

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -8,8 +8,8 @@ import (
 func TestNew(t *testing.T) {
 	s := "test"
 	u := New(s)
-	if u.String() != "1540300e31de262ee89774c014ac163d" {
-		t.Errorf("u is %v, expected %v", u, "1540300e31de262ee89774c014ac163d")
+	if u.String() != "e8b764da-5fe5-51ed-8af8-c5c6eca28d7a" {
+		t.Errorf("u is %v, expected %v", u, "e8b764da-5fe5-51ed-8af8-c5c6eca28d7a")
 	}
 
 	u2 := New(s)
@@ -20,14 +20,14 @@ func TestNew(t *testing.T) {
 }
 
 func TestUUIDString(t *testing.T) {
-	u := UUID("123e4567e89b12d3a456426655440000")
+	u := UUID("4f772915-1233-5679-845f-b4fe78c3115d")
 	s := u.String()
-	if s != "123e4567e89b12d3a456426655440000" {
-		t.Errorf("u.String() is %v, expected %v", s, "123e4567e89bi12d3a456426655440000")
+	if s != "4f772915-1233-5679-845f-b4fe78c3115d" {
+		t.Errorf("u.String() is %v, expected %v", s, "4f772915-1233-5679-845f-b4fe78c3115d")
 	}
 
 	s = fmt.Sprintf("%v", u)
-	if s != "123e4567e89b12d3a456426655440000" {
-		t.Errorf("u.String() is %v, expected %v", s, "123e4567e89b12d3a456426655440000")
+	if s != "4f772915-1233-5679-845f-b4fe78c3115d" {
+		t.Errorf("u.String() is %v, expected %v", s, "4f772915-1233-5679-845f-b4fe78c3115d")
 	}
 }

--- a/vendor/github.com/satori/go.uuid/LICENSE
+++ b/vendor/github.com/satori/go.uuid/LICENSE
@@ -1,0 +1,20 @@
+Copyright (C) 2013-2016 by Maxim Bublis <b@codemonkey.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/satori/go.uuid/uuid.go
+++ b/vendor/github.com/satori/go.uuid/uuid.go
@@ -1,0 +1,481 @@
+// Copyright (C) 2013-2015 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Package uuid provides implementation of Universally Unique Identifier (UUID).
+// Supported versions are 1, 3, 4 and 5 (as specified in RFC 4122) and
+// version 2 (as specified in DCE 1.1).
+package uuid
+
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"database/sql/driver"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+// UUID layout variants.
+const (
+	VariantNCS = iota
+	VariantRFC4122
+	VariantMicrosoft
+	VariantFuture
+)
+
+// UUID DCE domains.
+const (
+	DomainPerson = iota
+	DomainGroup
+	DomainOrg
+)
+
+// Difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and Unix epoch (January 1, 1970).
+const epochStart = 122192928000000000
+
+// Used in string method conversion
+const dash byte = '-'
+
+// UUID v1/v2 storage.
+var (
+	storageMutex  sync.Mutex
+	storageOnce   sync.Once
+	epochFunc     = unixTimeFunc
+	clockSequence uint16
+	lastTime      uint64
+	hardwareAddr  [6]byte
+	posixUID      = uint32(os.Getuid())
+	posixGID      = uint32(os.Getgid())
+)
+
+// String parse helpers.
+var (
+	urnPrefix  = []byte("urn:uuid:")
+	byteGroups = []int{8, 4, 4, 4, 12}
+)
+
+func initClockSequence() {
+	buf := make([]byte, 2)
+	safeRandom(buf)
+	clockSequence = binary.BigEndian.Uint16(buf)
+}
+
+func initHardwareAddr() {
+	interfaces, err := net.Interfaces()
+	if err == nil {
+		for _, iface := range interfaces {
+			if len(iface.HardwareAddr) >= 6 {
+				copy(hardwareAddr[:], iface.HardwareAddr)
+				return
+			}
+		}
+	}
+
+	// Initialize hardwareAddr randomly in case
+	// of real network interfaces absence
+	safeRandom(hardwareAddr[:])
+
+	// Set multicast bit as recommended in RFC 4122
+	hardwareAddr[0] |= 0x01
+}
+
+func initStorage() {
+	initClockSequence()
+	initHardwareAddr()
+}
+
+func safeRandom(dest []byte) {
+	if _, err := rand.Read(dest); err != nil {
+		panic(err)
+	}
+}
+
+// Returns difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and current time.
+// This is default epoch calculation function.
+func unixTimeFunc() uint64 {
+	return epochStart + uint64(time.Now().UnixNano()/100)
+}
+
+// UUID representation compliant with specification
+// described in RFC 4122.
+type UUID [16]byte
+
+// NullUUID can be used with the standard sql package to represent a
+// UUID value that can be NULL in the database
+type NullUUID struct {
+	UUID  UUID
+	Valid bool
+}
+
+// The nil UUID is special form of UUID that is specified to have all
+// 128 bits set to zero.
+var Nil = UUID{}
+
+// Predefined namespace UUIDs.
+var (
+	NamespaceDNS, _  = FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceURL, _  = FromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceOID, _  = FromString("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceX500, _ = FromString("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+)
+
+// And returns result of binary AND of two UUIDs.
+func And(u1 UUID, u2 UUID) UUID {
+	u := UUID{}
+	for i := 0; i < 16; i++ {
+		u[i] = u1[i] & u2[i]
+	}
+	return u
+}
+
+// Or returns result of binary OR of two UUIDs.
+func Or(u1 UUID, u2 UUID) UUID {
+	u := UUID{}
+	for i := 0; i < 16; i++ {
+		u[i] = u1[i] | u2[i]
+	}
+	return u
+}
+
+// Equal returns true if u1 and u2 equals, otherwise returns false.
+func Equal(u1 UUID, u2 UUID) bool {
+	return bytes.Equal(u1[:], u2[:])
+}
+
+// Version returns algorithm version used to generate UUID.
+func (u UUID) Version() uint {
+	return uint(u[6] >> 4)
+}
+
+// Variant returns UUID layout variant.
+func (u UUID) Variant() uint {
+	switch {
+	case (u[8] & 0x80) == 0x00:
+		return VariantNCS
+	case (u[8]&0xc0)|0x80 == 0x80:
+		return VariantRFC4122
+	case (u[8]&0xe0)|0xc0 == 0xc0:
+		return VariantMicrosoft
+	}
+	return VariantFuture
+}
+
+// Bytes returns bytes slice representation of UUID.
+func (u UUID) Bytes() []byte {
+	return u[:]
+}
+
+// Returns canonical string representation of UUID:
+// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+func (u UUID) String() string {
+	buf := make([]byte, 36)
+
+	hex.Encode(buf[0:8], u[0:4])
+	buf[8] = dash
+	hex.Encode(buf[9:13], u[4:6])
+	buf[13] = dash
+	hex.Encode(buf[14:18], u[6:8])
+	buf[18] = dash
+	hex.Encode(buf[19:23], u[8:10])
+	buf[23] = dash
+	hex.Encode(buf[24:], u[10:])
+
+	return string(buf)
+}
+
+// SetVersion sets version bits.
+func (u *UUID) SetVersion(v byte) {
+	u[6] = (u[6] & 0x0f) | (v << 4)
+}
+
+// SetVariant sets variant bits as described in RFC 4122.
+func (u *UUID) SetVariant() {
+	u[8] = (u[8] & 0xbf) | 0x80
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The encoding is the same as returned by String.
+func (u UUID) MarshalText() (text []byte, err error) {
+	text = []byte(u.String())
+	return
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// Following formats are supported:
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+// "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+// "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+func (u *UUID) UnmarshalText(text []byte) (err error) {
+	if len(text) < 32 {
+		err = fmt.Errorf("uuid: UUID string too short: %s", text)
+		return
+	}
+
+	t := text[:]
+	braced := false
+
+	if bytes.Equal(t[:9], urnPrefix) {
+		t = t[9:]
+	} else if t[0] == '{' {
+		braced = true
+		t = t[1:]
+	}
+
+	b := u[:]
+
+	for i, byteGroup := range byteGroups {
+		if i > 0 {
+			if t[0] != '-' {
+				err = fmt.Errorf("uuid: invalid string format")
+				return
+			}
+			t = t[1:]
+		}
+
+		if len(t) < byteGroup {
+			err = fmt.Errorf("uuid: UUID string too short: %s", text)
+			return
+		}
+
+		if i == 4 && len(t) > byteGroup &&
+			((braced && t[byteGroup] != '}') || len(t[byteGroup:]) > 1 || !braced) {
+			err = fmt.Errorf("uuid: UUID string too long: %s", text)
+			return
+		}
+
+		_, err = hex.Decode(b[:byteGroup/2], t[:byteGroup])
+		if err != nil {
+			return
+		}
+
+		t = t[byteGroup:]
+		b = b[byteGroup/2:]
+	}
+
+	return
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (u UUID) MarshalBinary() (data []byte, err error) {
+	data = u.Bytes()
+	return
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+// It will return error if the slice isn't 16 bytes long.
+func (u *UUID) UnmarshalBinary(data []byte) (err error) {
+	if len(data) != 16 {
+		err = fmt.Errorf("uuid: UUID must be exactly 16 bytes long, got %d bytes", len(data))
+		return
+	}
+	copy(u[:], data)
+
+	return
+}
+
+// Value implements the driver.Valuer interface.
+func (u UUID) Value() (driver.Value, error) {
+	return u.String(), nil
+}
+
+// Scan implements the sql.Scanner interface.
+// A 16-byte slice is handled by UnmarshalBinary, while
+// a longer byte slice or a string is handled by UnmarshalText.
+func (u *UUID) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		if len(src) == 16 {
+			return u.UnmarshalBinary(src)
+		}
+		return u.UnmarshalText(src)
+
+	case string:
+		return u.UnmarshalText([]byte(src))
+	}
+
+	return fmt.Errorf("uuid: cannot convert %T to UUID", src)
+}
+
+// Value implements the driver.Valuer interface.
+func (u NullUUID) Value() (driver.Value, error) {
+	if !u.Valid {
+		return nil, nil
+	}
+	// Delegate to UUID Value function
+	return u.UUID.Value()
+}
+
+// Scan implements the sql.Scanner interface.
+func (u *NullUUID) Scan(src interface{}) error {
+	if src == nil {
+		u.UUID, u.Valid = Nil, false
+		return nil
+	}
+
+	// Delegate to UUID Scan function
+	u.Valid = true
+	return u.UUID.Scan(src)
+}
+
+// FromBytes returns UUID converted from raw byte slice input.
+// It will return error if the slice isn't 16 bytes long.
+func FromBytes(input []byte) (u UUID, err error) {
+	err = u.UnmarshalBinary(input)
+	return
+}
+
+// FromBytesOrNil returns UUID converted from raw byte slice input.
+// Same behavior as FromBytes, but returns a Nil UUID on error.
+func FromBytesOrNil(input []byte) UUID {
+	uuid, err := FromBytes(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// FromString returns UUID parsed from string input.
+// Input is expected in a form accepted by UnmarshalText.
+func FromString(input string) (u UUID, err error) {
+	err = u.UnmarshalText([]byte(input))
+	return
+}
+
+// FromStringOrNil returns UUID parsed from string input.
+// Same behavior as FromString, but returns a Nil UUID on error.
+func FromStringOrNil(input string) UUID {
+	uuid, err := FromString(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// Returns UUID v1/v2 storage state.
+// Returns epoch timestamp, clock sequence, and hardware address.
+func getStorage() (uint64, uint16, []byte) {
+	storageOnce.Do(initStorage)
+
+	storageMutex.Lock()
+	defer storageMutex.Unlock()
+
+	timeNow := epochFunc()
+	// Clock changed backwards since last UUID generation.
+	// Should increase clock sequence.
+	if timeNow <= lastTime {
+		clockSequence++
+	}
+	lastTime = timeNow
+
+	return timeNow, clockSequence, hardwareAddr[:]
+}
+
+// NewV1 returns UUID based on current timestamp and MAC address.
+func NewV1() UUID {
+	u := UUID{}
+
+	timeNow, clockSeq, hardwareAddr := getStorage()
+
+	binary.BigEndian.PutUint32(u[0:], uint32(timeNow))
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(1)
+	u.SetVariant()
+
+	return u
+}
+
+// NewV2 returns DCE Security UUID based on POSIX UID/GID.
+func NewV2(domain byte) UUID {
+	u := UUID{}
+
+	timeNow, clockSeq, hardwareAddr := getStorage()
+
+	switch domain {
+	case DomainPerson:
+		binary.BigEndian.PutUint32(u[0:], posixUID)
+	case DomainGroup:
+		binary.BigEndian.PutUint32(u[0:], posixGID)
+	}
+
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+	u[9] = domain
+
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(2)
+	u.SetVariant()
+
+	return u
+}
+
+// NewV3 returns UUID based on MD5 hash of namespace UUID and name.
+func NewV3(ns UUID, name string) UUID {
+	u := newFromHash(md5.New(), ns, name)
+	u.SetVersion(3)
+	u.SetVariant()
+
+	return u
+}
+
+// NewV4 returns random generated UUID.
+func NewV4() UUID {
+	u := UUID{}
+	safeRandom(u[:])
+	u.SetVersion(4)
+	u.SetVariant()
+
+	return u
+}
+
+// NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
+func NewV5(ns UUID, name string) UUID {
+	u := newFromHash(sha1.New(), ns, name)
+	u.SetVersion(5)
+	u.SetVariant()
+
+	return u
+}
+
+// Returns UUID based on hashing of namespace UUID and name.
+func newFromHash(h hash.Hash, ns UUID, name string) UUID {
+	u := UUID{}
+	h.Write(ns[:])
+	h.Write([]byte(name))
+	copy(u[:], h.Sum(nil))
+
+	return u
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -24,6 +24,14 @@
 			"revision": "b8bc1bf767474819792c23f32d8286a45736f1c6",
 			"branch": "master",
 			"notests": true
+		},
+		{
+			"importpath": "github.com/satori/go.uuid",
+			"repository": "https://github.com/satori/go.uuid",
+			"vcs": "git",
+			"revision": "5bf94b69c6b68ee1b541973bb8e1144db23a194b",
+			"branch": "master",
+			"notests": true
 		}
 	]
 }


### PR DESCRIPTION
We replace our old [UUID implementation](https://github.com/fern4lvarez/piladb/tree/338837467f07aee1cf7b9a70fc580297c83b9232/pkg/uuid), which wasn't RFC 4122-compliant and use the Version 5 of https://github.com/satori/go.uuid, which is lightweight and well tested. This dependency is added to our vendor directory.

This PR doesn't change the logic of piladb, only the way the Stacks and Databases UUIDs are represented.