### PR TITLE
Use UUID Version 5 replacing md5 with sha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 - Add `FULL` operation
 - Add `ROTATE` operation
 
+### Changed
+- pkg/uuid: Replace md5 with sha1 and be compliant to Version 5 of RFC 4122
+
 ## [0.1.4] - 2017-06-20
 
 ### Added

--- a/pila/database_test.go
+++ b/pila/database_test.go
@@ -9,8 +9,8 @@ import (
 func TestNewDatabase(t *testing.T) {
 	db := NewDatabase("test-1")
 
-	if db.ID.String() != "485bab97-e873-0e1b-2be7-0283461fc53b" {
-		t.Errorf("db.ID is %v, expected %v", db.ID, "485bab97-e873-0e1b-2be7-0283461fc53b")
+	if db.ID.String() != "485bab97-e873-5e1b-abe7-0283461fc53b" {
+		t.Errorf("db.ID is %v, expected %v", db.ID, "485bab97-e873-5e1b-abe7-0283461fc53b")
 	}
 	if db.Name != "test-1" {
 		t.Errorf("db.Name is %v, expected %v", db.Name, "test-1")
@@ -167,7 +167,7 @@ func TestDatabaseStatus(t *testing.T) {
 	s2ID := db.CreateStack("s2", time.Now())
 
 	expectedStatus := DatabaseStatus{
-		ID:           "64626840-b923-4221-d637-1397cfffa702",
+		ID:           "64626840-b923-5221-9637-1397cfffa702",
 		Name:         "db",
 		NumberStacks: 3,
 		Stacks:       []string{s0ID.String(), s2ID.String(), s1ID.String()},
@@ -182,7 +182,7 @@ func TestDatabaseStatus_Empty(t *testing.T) {
 	db := NewDatabase("db")
 
 	expectedStatus := DatabaseStatus{
-		ID:           "64626840-b923-4221-d637-1397cfffa702",
+		ID:           "64626840-b923-5221-9637-1397cfffa702",
 		Name:         "db",
 		NumberStacks: 0,
 		Stacks:       []string{},

--- a/pila/database_test.go
+++ b/pila/database_test.go
@@ -9,8 +9,8 @@ import (
 func TestNewDatabase(t *testing.T) {
 	db := NewDatabase("test-1")
 
-	if db.ID.String() != "2b87e5d8b7d3d853514c8d0801fbcf46" {
-		t.Errorf("db.ID is %v, expected %v", db.ID, "2b87e5d8b7d3d853514c8d0801fbcf46")
+	if db.ID.String() != "485bab97-e873-0e1b-2be7-0283461fc53b" {
+		t.Errorf("db.ID is %v, expected %v", db.ID, "485bab97-e873-0e1b-2be7-0283461fc53b")
 	}
 	if db.Name != "test-1" {
 		t.Errorf("db.Name is %v, expected %v", db.Name, "test-1")
@@ -167,7 +167,7 @@ func TestDatabaseStatus(t *testing.T) {
 	s2ID := db.CreateStack("s2", time.Now())
 
 	expectedStatus := DatabaseStatus{
-		ID:           "8cfa8cb55c92fa403369a13fd12a8e01",
+		ID:           "64626840-b923-4221-d637-1397cfffa702",
 		Name:         "db",
 		NumberStacks: 3,
 		Stacks:       []string{s0ID.String(), s2ID.String(), s1ID.String()},
@@ -182,7 +182,7 @@ func TestDatabaseStatus_Empty(t *testing.T) {
 	db := NewDatabase("db")
 
 	expectedStatus := DatabaseStatus{
-		ID:           "8cfa8cb55c92fa403369a13fd12a8e01",
+		ID:           "64626840-b923-4221-d637-1397cfffa702",
 		Name:         "db",
 		NumberStacks: 0,
 		Stacks:       []string{},

--- a/pila/pila_test.go
+++ b/pila/pila_test.go
@@ -123,7 +123,7 @@ func TestPilaStatusToJSON(t *testing.T) {
 	db0 := NewDatabase("db0")
 	pila.AddDatabase(db0)
 
-	expectedStatus := `{"number_of_databases":1,"databases":[{"id":"714e49277eb730717e413b167b76ef78","name":"db0","number_of_stacks":0}]}`
+	expectedStatus := `{"number_of_databases":1,"databases":[{"id":"91010edc-36f6-25cc-5b10-f2648eb2b322","name":"db0","number_of_stacks":0}]}`
 
 	if status := pila.Status().ToJSON(); string(status) != expectedStatus {
 		t.Errorf("status is %s, expected %s", string(status), expectedStatus)

--- a/pila/pila_test.go
+++ b/pila/pila_test.go
@@ -123,7 +123,7 @@ func TestPilaStatusToJSON(t *testing.T) {
 	db0 := NewDatabase("db0")
 	pila.AddDatabase(db0)
 
-	expectedStatus := `{"number_of_databases":1,"databases":[{"id":"91010edc-36f6-25cc-5b10-f2648eb2b322","name":"db0","number_of_stacks":0}]}`
+	expectedStatus := `{"number_of_databases":1,"databases":[{"id":"91010edc-36f6-55cc-9b10-f2648eb2b322","name":"db0","number_of_stacks":0}]}`
 
 	if status := pila.Status().ToJSON(); string(status) != expectedStatus {
 		t.Errorf("status is %s, expected %s", string(status), expectedStatus)

--- a/pila/stack_status_test.go
+++ b/pila/stack_status_test.go
@@ -20,7 +20,7 @@ func TestStackStatusJSON(t *testing.T) {
 	stack.Push([]byte("test"))
 	stack.Update(after)
 
-	expectedStatus := fmt.Sprintf(`{"id":"2f44edeaa249ba81db20e9ddf000ba65","name":"test-stack","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStatus := fmt.Sprintf(`{"id":"c8fea3b0-26fd-7ffe-9006-0a71a50ae483","name":"test-stack","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(now.Local()),
 		date.Format(after.Local()),
 		date.Format(after.Local()))
@@ -36,7 +36,7 @@ func TestStackStatusJSON_Empty(t *testing.T) {
 	stack := NewStack("test-stack", now)
 	stack.Update(now)
 
-	expectedStatus := fmt.Sprintf(`{"id":"2f44edeaa249ba81db20e9ddf000ba65","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStatus := fmt.Sprintf(`{"id":"c8fea3b0-26fd-7ffe-9006-0a71a50ae483","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(now.Local()),
 		date.Format(now.Local()),
 		date.Format(now.Local()))
@@ -92,7 +92,7 @@ func TestStacksStatusJSON(t *testing.T) {
 		Stacks: []StackStatus{stack1.Status(), stack2.Status()},
 	}
 
-	expectedStatus := fmt.Sprintf(`{"stacks":[{"id":"a0bfff209889f6f782997a7bd5b3d536","name":"test-stack-1","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"f0d682fdfb3396c6f21e6f4d1d0da1cd","name":"test-stack-2","peek":999,"size":3,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
+	expectedStatus := fmt.Sprintf(`{"stacks":[{"id":"f6c83edc-f57a-8d0b-a79c-1e4fd365bce1","name":"test-stack-1","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"7fda1b97-80c9-d0f4-c6a4-a85d8dd3172d","name":"test-stack-2","peek":999,"size":3,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
 		date.Format(now.Local()), date.Format(after.Local()), date.Format(after.Local()),
 		date.Format(now.Local()), date.Format(after.Local()), date.Format(after.Local()))
 	if status, err := stacksStatus.ToJSON(); err != nil {

--- a/pila/stack_status_test.go
+++ b/pila/stack_status_test.go
@@ -20,7 +20,7 @@ func TestStackStatusJSON(t *testing.T) {
 	stack.Push([]byte("test"))
 	stack.Update(after)
 
-	expectedStatus := fmt.Sprintf(`{"id":"c8fea3b0-26fd-7ffe-9006-0a71a50ae483","name":"test-stack","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStatus := fmt.Sprintf(`{"id":"c8fea3b0-26fd-5ffe-9006-0a71a50ae483","name":"test-stack","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(now.Local()),
 		date.Format(after.Local()),
 		date.Format(after.Local()))
@@ -36,7 +36,7 @@ func TestStackStatusJSON_Empty(t *testing.T) {
 	stack := NewStack("test-stack", now)
 	stack.Update(now)
 
-	expectedStatus := fmt.Sprintf(`{"id":"c8fea3b0-26fd-7ffe-9006-0a71a50ae483","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStatus := fmt.Sprintf(`{"id":"c8fea3b0-26fd-5ffe-9006-0a71a50ae483","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(now.Local()),
 		date.Format(now.Local()),
 		date.Format(now.Local()))
@@ -92,7 +92,7 @@ func TestStacksStatusJSON(t *testing.T) {
 		Stacks: []StackStatus{stack1.Status(), stack2.Status()},
 	}
 
-	expectedStatus := fmt.Sprintf(`{"stacks":[{"id":"f6c83edc-f57a-8d0b-a79c-1e4fd365bce1","name":"test-stack-1","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"7fda1b97-80c9-d0f4-c6a4-a85d8dd3172d","name":"test-stack-2","peek":999,"size":3,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
+	expectedStatus := fmt.Sprintf(`{"stacks":[{"id":"f6c83edc-f57a-5d0b-a79c-1e4fd365bce1","name":"test-stack-1","peek":"dGVzdA==","size":4,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"7fda1b97-80c9-50f4-86a4-a85d8dd3172d","name":"test-stack-2","peek":999,"size":3,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
 		date.Format(now.Local()), date.Format(after.Local()), date.Format(after.Local()),
 		date.Format(now.Local()), date.Format(after.Local()), date.Format(after.Local()))
 	if status, err := stacksStatus.ToJSON(); err != nil {

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -27,8 +27,8 @@ func TestNewStack(t *testing.T) {
 		t.Fatal("stack is nil")
 	}
 
-	if stack.ID.String() != "c8fea3b0-26fd-7ffe-9006-0a71a50ae483" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "c8fea3b0-26fd-7ffe-9006-0a71a50ae483")
+	if stack.ID.String() != "c8fea3b0-26fd-5ffe-9006-0a71a50ae483" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "c8fea3b0-26fd-5ffe-9006-0a71a50ae483")
 	}
 	if stack.Name != "test-stack" {
 		t.Errorf("stack.Name is %s, expected %s", stack.Name, "test-stack")
@@ -55,8 +55,8 @@ func TestNewStackWithBase(t *testing.T) {
 		t.Fatal("stack is nil")
 	}
 
-	if stack.ID.String() != "c8fea3b0-26fd-7ffe-9006-0a71a50ae483" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "c8fea3b0-26fd-7ffe-9006-0a71a50ae483")
+	if stack.ID.String() != "c8fea3b0-26fd-5ffe-9006-0a71a50ae483" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "c8fea3b0-26fd-5ffe-9006-0a71a50ae483")
 	}
 	if stack.Name != "test-stack" {
 		t.Errorf("stack.Name is %s, expected %s", stack.Name, "test-stack")
@@ -337,8 +337,8 @@ func TestStackSetID(t *testing.T) {
 	stack.Database = db
 	stack.SetID()
 
-	if stack.ID.String() != "559cc77b-8dde-9e71-3b22-8f40bed1a39f" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "559cc77b-8dde-9e71-3b22-8f40bed1a39f")
+	if stack.ID.String() != "559cc77b-8dde-5e71-bb22-8f40bed1a39f" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "559cc77b-8dde-5e71-bb22-8f40bed1a39f")
 	}
 }
 
@@ -346,8 +346,8 @@ func TestStackSetID_NoDatabase(t *testing.T) {
 	stack := NewStack("test-stack", time.Now())
 	stack.SetID()
 
-	if stack.ID.String() != "c8fea3b0-26fd-7ffe-9006-0a71a50ae483" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "c8fea3b0-26fd-7ffe-9006-0a71a50ae483")
+	if stack.ID.String() != "c8fea3b0-26fd-5ffe-9006-0a71a50ae483" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "c8fea3b0-26fd-5ffe-9006-0a71a50ae483")
 	}
 }
 

--- a/pila/stack_test.go
+++ b/pila/stack_test.go
@@ -27,8 +27,8 @@ func TestNewStack(t *testing.T) {
 		t.Fatal("stack is nil")
 	}
 
-	if stack.ID.String() != "2f44edeaa249ba81db20e9ddf000ba65" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "2f44edeaa249ba81db20e9ddf000ba65")
+	if stack.ID.String() != "c8fea3b0-26fd-7ffe-9006-0a71a50ae483" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "c8fea3b0-26fd-7ffe-9006-0a71a50ae483")
 	}
 	if stack.Name != "test-stack" {
 		t.Errorf("stack.Name is %s, expected %s", stack.Name, "test-stack")
@@ -55,8 +55,8 @@ func TestNewStackWithBase(t *testing.T) {
 		t.Fatal("stack is nil")
 	}
 
-	if stack.ID.String() != "2f44edeaa249ba81db20e9ddf000ba65" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "2f44edeaa249ba81db20e9ddf000ba65")
+	if stack.ID.String() != "c8fea3b0-26fd-7ffe-9006-0a71a50ae483" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "c8fea3b0-26fd-7ffe-9006-0a71a50ae483")
 	}
 	if stack.Name != "test-stack" {
 		t.Errorf("stack.Name is %s, expected %s", stack.Name, "test-stack")
@@ -337,8 +337,8 @@ func TestStackSetID(t *testing.T) {
 	stack.Database = db
 	stack.SetID()
 
-	if stack.ID.String() != "378c2601e338a49341d9858081452226" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "378c2601e338a49341d9858081452226")
+	if stack.ID.String() != "559cc77b-8dde-9e71-3b22-8f40bed1a39f" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "559cc77b-8dde-9e71-3b22-8f40bed1a39f")
 	}
 }
 
@@ -346,8 +346,8 @@ func TestStackSetID_NoDatabase(t *testing.T) {
 	stack := NewStack("test-stack", time.Now())
 	stack.SetID()
 
-	if stack.ID.String() != "2f44edeaa249ba81db20e9ddf000ba65" {
-		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "2f44edeaa249ba81db20e9ddf000ba65")
+	if stack.ID.String() != "c8fea3b0-26fd-7ffe-9006-0a71a50ae483" {
+		t.Errorf("stack.ID is %s, expected %s", stack.ID.String(), "c8fea3b0-26fd-7ffe-9006-0a71a50ae483")
 	}
 }
 

--- a/pilad/README.md
+++ b/pilad/README.md
@@ -110,7 +110,7 @@ Returns `200 OK` and the status of the currently running databases.
     {
       "number_of_stacks": 0,
       "name": "db0",
-      "id": "714e49277eb730717e413b167b76ef78"
+      "id": "91010edc-36f6-25cc-5b10-f2648eb2b322"
     },
     {
       "number_of_stacks": 0,
@@ -138,7 +138,7 @@ is used as default, the latter as fallback.
 {
   "number_of_stacks": 0,
   "name": "db0",
-  "id": "714e49277eb730717e413b167b76ef78"
+  "id": "91010edc-36f6-25cc-5b10-f2648eb2b322"
 }
 ```
 
@@ -161,7 +161,7 @@ Returns `201 CREATED` and creates a new $DATABASE_NAME database.
 {
   "number_of_stacks": 0,
   "name": "db0",
-  "id": "714e49277eb730717e413b167b76ef78"
+  "id": "91010edc-36f6-25cc-5b10-f2648eb2b322"
 }
 ```
 
@@ -182,7 +182,7 @@ is used as default, the latter as fallback.
 {
   "stacks" : [
     {
-      "id":"f0306fec639bd57fc2929c8b897b9b37",
+      "id":"ef7199db-821c-80df-cdc0-ddc77fc6397e",
       "name":"stack1",
       "peek":"foo",
       "size":1,
@@ -191,7 +191,7 @@ is used as default, the latter as fallback.
       "read_at":"2016-12-08T18:21:270.813642732+01:00"
     },
     {
-      "id":"dde8f895aea2ffa5546336146b9384e7",
+      "id":"15860a24-e97c-aa2a-3e81-3d5066246cb6",
       "name":"stack2",
       "peek":8,
       "size":2,
@@ -240,7 +240,7 @@ Creates a new $STACK_NAME stack belonging to database $DATABASE_ID.
   "size": 0,
   "peek": null,
   "name": "stack",
-  "id": "714e49277eb730717e413b167b76ef78",
+  "id": "91010edc-36f6-25cc-5b10-f2648eb2b322",
   "created_at": "2016-12-08T17:45:50.668575679+01:00",
   "updated_at": "2016-12-08T17:45:50.668575679+01:00",
   "read_at": "2016-12-08T17:45:50.668575679+01:00"
@@ -265,7 +265,7 @@ is used as default, the latter as fallback.
   "size": 0,
   "peek": null,
   "name": "stack",
-  "id": "714e49277eb730717e413b167b76ef78",
+  "id": "91010edc-36f6-25cc-5b10-f2648eb2b322",
   "created_at": "2016-12-08T17:45:50.668575679+01:00",
   "updated_at": "2016-12-08T17:45:50.668575679+01:00",
   "read_at":"2016-12-08T18:17:32.456823273254+01:00"
@@ -440,7 +440,7 @@ is used as default, the latter as fallback.
   "size": 0,
   "peek": null,
   "name": "stack",
-  "id": "714e49277eb730717e413b167b76ef78",
+  "id": "91010edc-36f6-25cc-5b10-f2648eb2b322",
   "created_at": "2016-12-08T17:45:50.668575679+01:00",
   "updated_at": "2016-12-08T17:46:23.133256135+01:00",
   "read_at": "2016-12-08T17:46:23.133256135+01:00"

--- a/pilad/README.md
+++ b/pilad/README.md
@@ -110,7 +110,7 @@ Returns `200 OK` and the status of the currently running databases.
     {
       "number_of_stacks": 0,
       "name": "db0",
-      "id": "91010edc-36f6-25cc-5b10-f2648eb2b322"
+      "id": "91010edc-36f6-55cc-9b10-f2648eb2b322"
     },
     {
       "number_of_stacks": 0,
@@ -138,7 +138,7 @@ is used as default, the latter as fallback.
 {
   "number_of_stacks": 0,
   "name": "db0",
-  "id": "91010edc-36f6-25cc-5b10-f2648eb2b322"
+  "id": "91010edc-36f6-55cc-9b10-f2648eb2b322"
 }
 ```
 
@@ -161,7 +161,7 @@ Returns `201 CREATED` and creates a new $DATABASE_NAME database.
 {
   "number_of_stacks": 0,
   "name": "db0",
-  "id": "91010edc-36f6-25cc-5b10-f2648eb2b322"
+  "id": "91010edc-36f6-55cc-9b10-f2648eb2b322"
 }
 ```
 
@@ -182,7 +182,7 @@ is used as default, the latter as fallback.
 {
   "stacks" : [
     {
-      "id":"ef7199db-821c-80df-cdc0-ddc77fc6397e",
+      "id":"ef7199db-821c-50df-8dc0-ddc77fc6397e",
       "name":"stack1",
       "peek":"foo",
       "size":1,
@@ -191,7 +191,7 @@ is used as default, the latter as fallback.
       "read_at":"2016-12-08T18:21:270.813642732+01:00"
     },
     {
-      "id":"15860a24-e97c-aa2a-3e81-3d5066246cb6",
+      "id":"15860a24-e97c-5a2a-be81-3d5066246cb6",
       "name":"stack2",
       "peek":8,
       "size":2,
@@ -240,7 +240,7 @@ Creates a new $STACK_NAME stack belonging to database $DATABASE_ID.
   "size": 0,
   "peek": null,
   "name": "stack",
-  "id": "91010edc-36f6-25cc-5b10-f2648eb2b322",
+  "id": "91010edc-36f6-55cc-9b10-f2648eb2b322",
   "created_at": "2016-12-08T17:45:50.668575679+01:00",
   "updated_at": "2016-12-08T17:45:50.668575679+01:00",
   "read_at": "2016-12-08T17:45:50.668575679+01:00"
@@ -265,7 +265,7 @@ is used as default, the latter as fallback.
   "size": 0,
   "peek": null,
   "name": "stack",
-  "id": "91010edc-36f6-25cc-5b10-f2648eb2b322",
+  "id": "91010edc-36f6-55cc-9b10-f2648eb2b322",
   "created_at": "2016-12-08T17:45:50.668575679+01:00",
   "updated_at": "2016-12-08T17:45:50.668575679+01:00",
   "read_at":"2016-12-08T18:17:32.456823273254+01:00"
@@ -440,7 +440,7 @@ is used as default, the latter as fallback.
   "size": 0,
   "peek": null,
   "name": "stack",
-  "id": "91010edc-36f6-25cc-5b10-f2648eb2b322",
+  "id": "91010edc-36f6-55cc-9b10-f2648eb2b322",
   "created_at": "2016-12-08T17:45:50.668575679+01:00",
   "updated_at": "2016-12-08T17:46:23.133256135+01:00",
   "read_at": "2016-12-08T17:46:23.133256135+01:00"

--- a/pilad/conn_test.go
+++ b/pilad/conn_test.go
@@ -164,7 +164,7 @@ func TestDatabasesHandler_GET(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := `{"number_of_databases":1,"databases":[{"id":"8cfa8cb55c92fa403369a13fd12a8e01","name":"db","number_of_stacks":0}]}`; string(databases) != expected {
+	if expected := `{"number_of_databases":1,"databases":[{"id":"64626840-b923-4221-d637-1397cfffa702","name":"db","number_of_stacks":0}]}`; string(databases) != expected {
 		t.Errorf("databases are %s, expected %s", string(databases), expected)
 	}
 }
@@ -237,8 +237,8 @@ func TestCreateDatabaseHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if string(databases) != `{"id":"8cfa8cb55c92fa403369a13fd12a8e01","name":"db","number_of_stacks":0}` {
-		t.Errorf("databases are %s, expected %s", string(databases), `{"id":"8cfa8cb55c92fa403369a13fd12a8e01","name":"db","number_of_stacks":0}`)
+	if string(databases) != `{"id":"64626840-b923-4221-d637-1397cfffa702","name":"db","number_of_stacks":0}` {
+		t.Errorf("databases are %s, expected %s", string(databases), `{"id":"64626840-b923-4221-d637-1397cfffa702","name":"db","number_of_stacks":0}`)
 	}
 }
 
@@ -324,7 +324,7 @@ func TestDatabaseHandler_GET(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := `{"id":"c13cec0e70876381c78c616ee2d809eb","name":"mydb","number_of_stacks":1,"stacks":["b92f53fa3884305ef798fd8c5d7609ad"]}`; string(database) != expected {
+	if expected := `{"id":"501214ca-0ade-f5f8-0efe-663e7c27267e","name":"mydb","number_of_stacks":1,"stacks":["7b6fee1b-9cdf-ba44-407e-7c171924dcf1"]}`; string(database) != expected {
 		t.Errorf("database is %v, expected %v", string(database), expected)
 	}
 }
@@ -368,7 +368,7 @@ func TestDatabaseHandler_GET_Name(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := `{"id":"c13cec0e70876381c78c616ee2d809eb","name":"mydb","number_of_stacks":1,"stacks":["b92f53fa3884305ef798fd8c5d7609ad"]}`; string(database) != expected {
+	if expected := `{"id":"501214ca-0ade-f5f8-0efe-663e7c27267e","name":"mydb","number_of_stacks":1,"stacks":["7b6fee1b-9cdf-ba44-407e-7c171924dcf1"]}`; string(database) != expected {
 		t.Errorf("database is %v, expected %v", string(database), expected)
 	}
 }
@@ -488,7 +488,7 @@ func TestStacksHandler_GET(t *testing.T) {
 	inputOutput := []struct {
 		input, output string
 	}{
-		{"/databases/db/stacks", fmt.Sprintf(`{"stacks":[{"id":"f0306fec639bd57fc2929c8b897b9b37","name":"stack1","peek":"foo","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"dde8f895aea2ffa5546336146b9384e7","name":"stack2","peek":8,"size":2,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
+		{"/databases/db/stacks", fmt.Sprintf(`{"stacks":[{"id":"ef7199db-821c-80df-cdc0-ddc77fc6397e","name":"stack1","peek":"foo","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"15860a24-e97c-aa2a-3e81-3d5066246cb6","name":"stack2","peek":8,"size":2,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
 			date.Format(now1.Local()), date.Format(after1.Local()), date.Format(after1.Local()),
 			date.Format(now2.Local()), date.Format(after2.Local()), date.Format(after2.Local()))},
 		{"/databases/db/stacks?kv", `{"stacks":{"stack1":"foo","stack2":8}}`},
@@ -569,7 +569,7 @@ func TestStacksHandler_GET_Name(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := fmt.Sprintf(`{"stacks":[{"id":"f0306fec639bd57fc2929c8b897b9b37","name":"stack1","peek":"bar","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"dde8f895aea2ffa5546336146b9384e7","name":"stack2","peek":"{\"a\":\"b\"}","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
+	if expected := fmt.Sprintf(`{"stacks":[{"id":"ef7199db-821c-80df-cdc0-ddc77fc6397e","name":"stack1","peek":"bar","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"15860a24-e97c-aa2a-3e81-3d5066246cb6","name":"stack2","peek":"{\"a\":\"b\"}","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
 		date.Format(now1.Local()), date.Format(after1.Local()), date.Format(after1.Local()),
 		date.Format(now2.Local()), date.Format(after2.Local()), date.Format(after2.Local())); string(stacks) != expected {
 		t.Errorf("stacks are %s, expected %s", string(stacks), expected)
@@ -661,7 +661,7 @@ func TestStacksHandler_PUT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedStack := fmt.Sprintf(`{"id":"bb4dabeeaa6e90108583ddbf49649427","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStack := fmt.Sprintf(`{"id":"34497edc-f8bc-9918-a7d0-a1e70d0023da","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 
 	if string(stack) != expectedStack {
@@ -702,7 +702,7 @@ func TestStacksHandler_PUT_Name(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedStack := fmt.Sprintf(`{"id":"bb4dabeeaa6e90108583ddbf49649427","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStack := fmt.Sprintf(`{"id":"34497edc-f8bc-9918-a7d0-a1e70d0023da","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 
 	if string(stack) != expectedStack {
@@ -742,7 +742,7 @@ func TestCreateStackHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedStack := fmt.Sprintf(`{"id":"bb4dabeeaa6e90108583ddbf49649427","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStack := fmt.Sprintf(`{"id":"34497edc-f8bc-9918-a7d0-a1e70d0023da","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 	if string(stack) != expectedStack {
 		t.Errorf("stack is %s, expected %s", string(stack), expectedStack)

--- a/pilad/conn_test.go
+++ b/pilad/conn_test.go
@@ -164,7 +164,7 @@ func TestDatabasesHandler_GET(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := `{"number_of_databases":1,"databases":[{"id":"64626840-b923-4221-d637-1397cfffa702","name":"db","number_of_stacks":0}]}`; string(databases) != expected {
+	if expected := `{"number_of_databases":1,"databases":[{"id":"64626840-b923-5221-9637-1397cfffa702","name":"db","number_of_stacks":0}]}`; string(databases) != expected {
 		t.Errorf("databases are %s, expected %s", string(databases), expected)
 	}
 }
@@ -237,8 +237,8 @@ func TestCreateDatabaseHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if string(databases) != `{"id":"64626840-b923-4221-d637-1397cfffa702","name":"db","number_of_stacks":0}` {
-		t.Errorf("databases are %s, expected %s", string(databases), `{"id":"64626840-b923-4221-d637-1397cfffa702","name":"db","number_of_stacks":0}`)
+	if string(databases) != `{"id":"64626840-b923-5221-9637-1397cfffa702","name":"db","number_of_stacks":0}` {
+		t.Errorf("databases are %s, expected %s", string(databases), `{"id":"64626840-b923-5221-9637-1397cfffa702","name":"db","number_of_stacks":0}`)
 	}
 }
 
@@ -324,7 +324,7 @@ func TestDatabaseHandler_GET(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := `{"id":"501214ca-0ade-f5f8-0efe-663e7c27267e","name":"mydb","number_of_stacks":1,"stacks":["7b6fee1b-9cdf-ba44-407e-7c171924dcf1"]}`; string(database) != expected {
+	if expected := `{"id":"501214ca-0ade-55f8-8efe-663e7c27267e","name":"mydb","number_of_stacks":1,"stacks":["7b6fee1b-9cdf-5a44-807e-7c171924dcf1"]}`; string(database) != expected {
 		t.Errorf("database is %v, expected %v", string(database), expected)
 	}
 }
@@ -368,7 +368,7 @@ func TestDatabaseHandler_GET_Name(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := `{"id":"501214ca-0ade-f5f8-0efe-663e7c27267e","name":"mydb","number_of_stacks":1,"stacks":["7b6fee1b-9cdf-ba44-407e-7c171924dcf1"]}`; string(database) != expected {
+	if expected := `{"id":"501214ca-0ade-55f8-8efe-663e7c27267e","name":"mydb","number_of_stacks":1,"stacks":["7b6fee1b-9cdf-5a44-807e-7c171924dcf1"]}`; string(database) != expected {
 		t.Errorf("database is %v, expected %v", string(database), expected)
 	}
 }
@@ -488,7 +488,7 @@ func TestStacksHandler_GET(t *testing.T) {
 	inputOutput := []struct {
 		input, output string
 	}{
-		{"/databases/db/stacks", fmt.Sprintf(`{"stacks":[{"id":"ef7199db-821c-80df-cdc0-ddc77fc6397e","name":"stack1","peek":"foo","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"15860a24-e97c-aa2a-3e81-3d5066246cb6","name":"stack2","peek":8,"size":2,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
+		{"/databases/db/stacks", fmt.Sprintf(`{"stacks":[{"id":"ef7199db-821c-50df-8dc0-ddc77fc6397e","name":"stack1","peek":"foo","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"15860a24-e97c-5a2a-be81-3d5066246cb6","name":"stack2","peek":8,"size":2,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
 			date.Format(now1.Local()), date.Format(after1.Local()), date.Format(after1.Local()),
 			date.Format(now2.Local()), date.Format(after2.Local()), date.Format(after2.Local()))},
 		{"/databases/db/stacks?kv", `{"stacks":{"stack1":"foo","stack2":8}}`},
@@ -569,7 +569,7 @@ func TestStacksHandler_GET_Name(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := fmt.Sprintf(`{"stacks":[{"id":"ef7199db-821c-80df-cdc0-ddc77fc6397e","name":"stack1","peek":"bar","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"15860a24-e97c-aa2a-3e81-3d5066246cb6","name":"stack2","peek":"{\"a\":\"b\"}","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
+	if expected := fmt.Sprintf(`{"stacks":[{"id":"ef7199db-821c-50df-8dc0-ddc77fc6397e","name":"stack1","peek":"bar","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"},{"id":"15860a24-e97c-5a2a-be81-3d5066246cb6","name":"stack2","peek":"{\"a\":\"b\"}","size":1,"created_at":"%v","updated_at":"%v","read_at":"%v"}]}`,
 		date.Format(now1.Local()), date.Format(after1.Local()), date.Format(after1.Local()),
 		date.Format(now2.Local()), date.Format(after2.Local()), date.Format(after2.Local())); string(stacks) != expected {
 		t.Errorf("stacks are %s, expected %s", string(stacks), expected)
@@ -661,7 +661,7 @@ func TestStacksHandler_PUT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedStack := fmt.Sprintf(`{"id":"34497edc-f8bc-9918-a7d0-a1e70d0023da","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStack := fmt.Sprintf(`{"id":"34497edc-f8bc-5918-a7d0-a1e70d0023da","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 
 	if string(stack) != expectedStack {
@@ -702,7 +702,7 @@ func TestStacksHandler_PUT_Name(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedStack := fmt.Sprintf(`{"id":"34497edc-f8bc-9918-a7d0-a1e70d0023da","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStack := fmt.Sprintf(`{"id":"34497edc-f8bc-5918-a7d0-a1e70d0023da","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 
 	if string(stack) != expectedStack {
@@ -742,7 +742,7 @@ func TestCreateStackHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedStack := fmt.Sprintf(`{"id":"34497edc-f8bc-9918-a7d0-a1e70d0023da","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
+	expectedStack := fmt.Sprintf(`{"id":"34497edc-f8bc-5918-a7d0-a1e70d0023da","name":"test-stack","peek":null,"size":0,"created_at":"%v","updated_at":"%v","read_at":"%v"}`,
 		date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()), date.Format(conn.opDate.Local()))
 	if string(stack) != expectedStack {
 		t.Errorf("stack is %s, expected %s", string(stack), expectedStack)

--- a/pkg/uuid/README.md
+++ b/pkg/uuid/README.md
@@ -1,6 +1,5 @@
 uuid
 ====
 
-Special thanks to [dynport](http://github.com/dynport) for influencing on this UUID
-implementation.
+It uses UUID Version 5, based on SHA-1 hashing (RFC 4122).
 

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -4,28 +4,57 @@ package uuid
 
 import (
 	"crypto/hmac"
-	"crypto/md5"
-	"fmt"
+	"crypto/sha1"
+	"encoding/hex"
 )
 
 // seed must never change
 const seed = "bsa9phh6keet1ogh9ChoeNoK1jae8ro0"
 
-// UUID is a type used as identifier, following
+// dash represents - as a byte
+const dash byte = '-'
+
+// UUID is a type used as identifier, compliant with
+// Version 5 of RFC 4122:
 // https://www.ietf.org/rfc/rfc4122.txt
 type UUID string
 
 // New creates a new UUID given a string.
-func New(s string) UUID {
-	h := hmac.New(md5.New, []byte(seed))
+func New(input string) UUID {
+	id := hmac.New(sha1.New, []byte(seed))
 	// we ignore errors, since it is not
 	// testable
-	_, _ = h.Write([]byte(s))
-	return UUID(fmt.Sprintf("%x", h.Sum(nil)))
+	_, _ = id.Write([]byte(input))
+	b := id.Sum(nil)
+	return UUID(Canonical(b))
 }
 
 // String returns a string representation of the
 // UUID, implementing the Stringer interface.
-func (uuid UUID) String() string {
-	return string(uuid)
+func (u UUID) String() string {
+	return string(u)
+}
+
+// Canonical converts an array of bytes into the
+// canonical representation of UUID:
+// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+func Canonical(b []byte) string {
+	if len(b) < 16 {
+		z := make([]byte, 16-len(b))
+		b = append(z, b...)
+	}
+
+	buf := make([]byte, 36)
+
+	hex.Encode(buf[0:8], b[0:4])
+	buf[8] = dash
+	hex.Encode(buf[9:13], b[4:6])
+	buf[13] = dash
+	hex.Encode(buf[14:18], b[6:8])
+	buf[18] = dash
+	hex.Encode(buf[19:23], b[8:10])
+	buf[23] = dash
+	hex.Encode(buf[24:], b[10:16])
+
+	return string(buf)
 }

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -37,12 +37,21 @@ func (u UUID) String() string {
 
 // Canonical converts an array of bytes into the
 // canonical representation of UUID:
-// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+// xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx.
+// The one to three most significant bits of digit N
+// indicate the UUID variant and the four bits of digit M
+// indicate the UUID version.
 func Canonical(b []byte) string {
 	if len(b) < 16 {
 		z := make([]byte, 16-len(b))
 		b = append(z, b...)
 	}
+
+	// set UUID Version 5
+	b[6] = (b[6] & 0x0f) | (5 << 4)
+
+	// set variants
+	b[8] = (b[8] & 0xbf) | 0x80
 
 	buf := make([]byte, 36)
 

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -1,6 +1,7 @@
 package uuid
 
 import (
+	"encoding/hex"
 	"fmt"
 	"testing"
 )
@@ -8,8 +9,8 @@ import (
 func TestNew(t *testing.T) {
 	s := "test"
 	u := New(s)
-	if u.String() != "1540300e31de262ee89774c014ac163d" {
-		t.Errorf("u is %v, expected %v", u, "1540300e31de262ee89774c014ac163d")
+	if u.String() != "343345ce-8555-1655-db33-5945ace62f1c" {
+		t.Errorf("u is %v, expected %v", u, "343345ce-8555-1655-db33-5945ace62f1c")
 	}
 
 	u2 := New(s)
@@ -20,14 +21,45 @@ func TestNew(t *testing.T) {
 }
 
 func TestUUIDString(t *testing.T) {
-	u := UUID("123e4567e89b12d3a456426655440000")
+	u := UUID("68dc78ce-5de1-11e7-907b-a6006ad3dba0")
 	s := u.String()
-	if s != "123e4567e89b12d3a456426655440000" {
-		t.Errorf("u.String() is %v, expected %v", s, "123e4567e89bi12d3a456426655440000")
+	if s != "68dc78ce-5de1-11e7-907b-a6006ad3dba0" {
+		t.Errorf("u.String() is %v, expected %v", s, "68dc78ce-5de1-11e7-907b-a6006ad3dba0")
 	}
 
 	s = fmt.Sprintf("%v", u)
-	if s != "123e4567e89b12d3a456426655440000" {
-		t.Errorf("u.String() is %v, expected %v", s, "123e4567e89b12d3a456426655440000")
+	if s != "68dc78ce-5de1-11e7-907b-a6006ad3dba0" {
+		t.Errorf("u.String() is %v, expected %v", s, "68dc78ce-5de1-11e7-907b-a6006ad3dba0")
+	}
+}
+
+func TestCanonical(t *testing.T) {
+	b, _ := hex.DecodeString("e494f6205de211e7907ba6006ad3dba0")
+	expectedUUID := "e494f620-5de2-11e7-907b-a6006ad3dba0"
+
+	s := Canonical(b)
+	if s != expectedUUID {
+		t.Errorf("Canonical UUID is %s, expected %s", s, expectedUUID)
+	}
+}
+
+func TestCanonical_Short(t *testing.T) {
+	b := []byte("abcdefgh")
+	expectedUUID := "00000000-0000-0000-6162-636465666768"
+
+	s := Canonical(b)
+	if s != expectedUUID {
+		t.Errorf("Canonical UUID is %s, expected %s", s, expectedUUID)
+	}
+}
+
+func TestCanonical_Long(t *testing.T) {
+	b, _ := hex.DecodeString("e494f6205de211e7907ba6006ad3dba0")
+	b = append(b, []byte("xxxxxxxxxxxxxxxxxx")...)
+	expectedUUID := "e494f620-5de2-11e7-907b-a6006ad3dba0"
+
+	s := Canonical(b)
+	if s != expectedUUID {
+		t.Errorf("Canonical UUID is %s, expected %s", s, expectedUUID)
 	}
 }

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -9,8 +9,8 @@ import (
 func TestNew(t *testing.T) {
 	s := "test"
 	u := New(s)
-	if u.String() != "343345ce-8555-1655-db33-5945ace62f1c" {
-		t.Errorf("u is %v, expected %v", u, "343345ce-8555-1655-db33-5945ace62f1c")
+	if u.String() != "343345ce-8555-5655-9b33-5945ace62f1c" {
+		t.Errorf("u is %v, expected %v", u, "343345ce-8555-5655-9b33-5945ace62f1c")
 	}
 
 	u2 := New(s)
@@ -35,7 +35,7 @@ func TestUUIDString(t *testing.T) {
 
 func TestCanonical(t *testing.T) {
 	b, _ := hex.DecodeString("e494f6205de211e7907ba6006ad3dba0")
-	expectedUUID := "e494f620-5de2-11e7-907b-a6006ad3dba0"
+	expectedUUID := "e494f620-5de2-51e7-907b-a6006ad3dba0"
 
 	s := Canonical(b)
 	if s != expectedUUID {
@@ -45,7 +45,7 @@ func TestCanonical(t *testing.T) {
 
 func TestCanonical_Short(t *testing.T) {
 	b := []byte("abcdefgh")
-	expectedUUID := "00000000-0000-0000-6162-636465666768"
+	expectedUUID := "00000000-0000-5000-a162-636465666768"
 
 	s := Canonical(b)
 	if s != expectedUUID {
@@ -56,7 +56,7 @@ func TestCanonical_Short(t *testing.T) {
 func TestCanonical_Long(t *testing.T) {
 	b, _ := hex.DecodeString("e494f6205de211e7907ba6006ad3dba0")
 	b = append(b, []byte("xxxxxxxxxxxxxxxxxx")...)
-	expectedUUID := "e494f620-5de2-11e7-907b-a6006ad3dba0"
+	expectedUUID := "e494f620-5de2-51e7-907b-a6006ad3dba0"
 
 	s := Canonical(b)
 	if s != expectedUUID {


### PR DESCRIPTION
This PR supersedes https://github.com/fern4lvarez/piladb/pull/76.

We needed to replace md5 with sha1 hashing for security reasons, and originally we wanted to use an external library, like https://github.com/satori/go.uuid.

After putting some thoughts on this, we came up with the conclusion that was more sensible to keep with the philosophy of keeping the third part dependencies as small as possible. Thus, we stick compliant to RFC 4122, but using a simplified Version 5 of the UUID protocol.