### PR TITLE
Introduce graceful shutdown to pilad server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Add option to allow pushing on a Stack when this is full
+- Add graceful shutdown of pilad server
 - Add `BASE` operation
 - Add `EMPTY` operation
 - Add `FULL` operation

--- a/config/value.go
+++ b/config/value.go
@@ -30,6 +30,14 @@ func (c *Config) WriteTimeout() time.Duration {
 	return time.Duration(t)
 }
 
+// ShutdownTimeout returns the value of SHUTDOWN_TIMEOUT.
+// Type: time.Duration, Default: 15
+func (c *Config) ShutdownTimeout() time.Duration {
+	shutdownTimeout := c.Get(vars.ShutdownTimeout)
+	t := intValue(shutdownTimeout, vars.ShutdownTimeoutDefault)
+	return time.Duration(t)
+}
+
 // Port returns the value of PORT.
 // Type: int, Default: 1205
 func (c *Config) Port() int {

--- a/config/value_test.go
+++ b/config/value_test.go
@@ -80,6 +80,30 @@ func TestWriteTimeout(t *testing.T) {
 	}
 }
 
+func TestShutdownTimeout(t *testing.T) {
+	c := NewConfig()
+
+	inputOutput := []struct {
+		input  interface{}
+		output time.Duration
+	}{
+		{8, 8},
+		{108.8, 108},
+		{"3", 3},
+		{-1, vars.ShutdownTimeoutDefault},
+		{"foo", vars.ShutdownTimeoutDefault},
+		{[]byte("foo"), vars.ShutdownTimeoutDefault},
+	}
+
+	for _, io := range inputOutput {
+		c.Set(vars.ShutdownTimeout, io.input)
+
+		if s := c.ShutdownTimeout(); s != io.output {
+			t.Errorf("ShutdownTimeout is %d, expected %d", s, io.output)
+		}
+	}
+}
+
 func TestPort(t *testing.T) {
 	c := NewConfig()
 

--- a/config/vars/vars.go
+++ b/config/vars/vars.go
@@ -28,6 +28,14 @@ const (
 	// of WriteTimeout.
 	WriteTimeoutDefault = 45
 
+	// ShutdownTimeout is the maximun duration
+	// allowed for remaining operations to finish
+	// before pilad is shutdown.
+	ShutdownTimeout = "SHUTDOWN_TIMEOUT"
+	// ShutdownTimeoutDefault represents the default value
+	// of ShutdownTimeout.
+	ShutdownTimeoutDefault = 15
+
 	// Port is the TCP port number where pilad
 	// is running. Port number range is 1025-65536.
 	Port = "PORT"
@@ -60,6 +68,8 @@ func DefaultInt(name string) int {
 		return ReadTimeoutDefault
 	case WriteTimeout:
 		return WriteTimeoutDefault
+	case ShutdownTimeout:
+		return ShutdownTimeoutDefault
 	case Port:
 		return PortDefault
 	}

--- a/config/vars/vars_test.go
+++ b/config/vars/vars_test.go
@@ -19,6 +19,7 @@ func TestDefaultInt(t *testing.T) {
 		{MaxStackSize, MaxStackSizeDefault},
 		{ReadTimeout, ReadTimeoutDefault},
 		{WriteTimeout, WriteTimeoutDefault},
+		{ShutdownTimeout, ShutdownTimeoutDefault},
 		{Port, PortDefault},
 		{"foo", -1},
 	}

--- a/pilad/config.go
+++ b/pilad/config.go
@@ -17,17 +17,18 @@ import (
 // They are only used to initialize the Connection
 // Config at pilad start-up.
 var (
-	maxStackSizeFlag                  int
-	readTimeoutFlag, writeTimeoutFlag int
-	portFlag                          int
-	pushWhenFullFlag                  bool
-	versionFlag                       bool
+	maxStackSizeFlag                                       int
+	readTimeoutFlag, writeTimeoutFlag, shutdownTimeoutFlag int
+	portFlag                                               int
+	pushWhenFullFlag                                       bool
+	versionFlag                                            bool
 )
 
 func init() {
 	flag.IntVar(&maxStackSizeFlag, "max-stack-size", vars.MaxStackSizeDefault, "Max size of Stacks")
 	flag.IntVar(&readTimeoutFlag, "read-timeout", vars.ReadTimeoutDefault, "Read request timeout")
 	flag.IntVar(&writeTimeoutFlag, "write-timeout", vars.WriteTimeoutDefault, "Write response timeout")
+	flag.IntVar(&shutdownTimeoutFlag, "shutdown-timeout", vars.ShutdownTimeoutDefault, "Graceful shutdown timeout")
 	flag.IntVar(&portFlag, "port", vars.PortDefault, "Port number")
 	flag.BoolVar(&pushWhenFullFlag, "push-when-full", vars.PushWhenFullDefault, "Allow push when Stack is full")
 	flag.BoolVar(&versionFlag, "v", false, "Version")
@@ -45,6 +46,7 @@ func (c *Conn) buildConfig() {
 		{maxStackSizeFlag, vars.MaxStackSize},
 		{readTimeoutFlag, vars.ReadTimeout},
 		{writeTimeoutFlag, vars.WriteTimeout},
+		{shutdownTimeoutFlag, vars.ShutdownTimeout},
 		{portFlag, vars.Port},
 		{pushWhenFullFlag, vars.PushWhenFull},
 	}

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -21,7 +21,7 @@ const (
 	PUT = "PUT"
 	// POST represents the POST HTTP method
 	POST = "POST"
-	// DELETE representes the DELETE HTTP method
+	// DELETE represents the DELETE HTTP method
 	DELETE = "DELETE"
 )
 
@@ -36,10 +36,10 @@ type Conn struct {
 	// resources management.
 	Status *Status
 
-	// srv representes the http Server where the connection
+	// srv represents the http Server where the connection
 	// is running.
 	srv *http.Server
-	// opDate holds the date an ocurring
+	// opDate holds the date an on-going
 	// operation was requested.
 	opDate time.Time
 	// idle is a channel that will make server

--- a/pilad/conn.go
+++ b/pilad/conn.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -35,7 +36,19 @@ type Conn struct {
 	// resources management.
 	Status *Status
 
+	// srv representes the http Server where the connection
+	// is running.
+	srv *http.Server
+	// opDate holds the date an ocurring
+	// operation was requested.
 	opDate time.Time
+	// idle is a channel that will make server
+	// idle until all connections are freed up.
+	// see pilad/shutdown.go
+	idle chan struct{}
+	// stop holds a signal to interrupt or terminate
+	// the server.
+	stop chan os.Signal
 }
 
 // NewConn creates and returns a new piladb connection.
@@ -44,6 +57,8 @@ func NewConn() *Conn {
 	conn.Pila = pila.NewPila()
 	conn.Config = config.NewConfig()
 	conn.Status = NewStatus(v(), time.Now().UTC(), MemStats())
+	conn.idle = make(chan struct{})
+	conn.stop = make(chan os.Signal, 1)
 	return conn
 }
 

--- a/pilad/main.go
+++ b/pilad/main.go
@@ -5,8 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net/http"
-	"time"
 )
 
 func main() {
@@ -16,15 +14,7 @@ func main() {
 		return
 	}
 
-	conn := NewConn()
-	conn.buildConfig()
-	logo(conn)
-
-	srv := &http.Server{
-		Addr:         fmt.Sprintf(":%d", conn.Config.Port()),
-		Handler:      Router(conn),
-		ReadTimeout:  conn.Config.ReadTimeout() * time.Second,
-		WriteTimeout: conn.Config.WriteTimeout() * time.Second,
+	if err := start(NewConn()); err != nil {
+		log.Println(err)
 	}
-	log.Fatal(srv.ListenAndServe())
 }

--- a/pilad/main_test.go
+++ b/pilad/main_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 )
 
-// TestMain is a hack to get 100% test coverage.
 func TestMain(t *testing.T) {
 	os.Setenv("PILADB_PORT", "35343")
 	go main()
@@ -14,7 +13,15 @@ func TestMain(t *testing.T) {
 	os.Setenv("PILADB_PORT", "")
 }
 
-func TestMainVersion(t *testing.T) {
+func TestMain_Error(t *testing.T) {
+	os.Setenv("PILADB_PORT", "35343")
+	go main()
+	go main()
+	time.Sleep(5 * time.Millisecond)
+	os.Setenv("PILADB_PORT", "")
+}
+
+func TestMain_Version(t *testing.T) {
 	versionFlag = true
 	go main()
 	t.Log(v())

--- a/pilad/server.go
+++ b/pilad/server.go
@@ -34,9 +34,10 @@ func listenGracefulShutdown(conn *Conn) {
 	signal.Notify(conn.stop, os.Interrupt, syscall.SIGTERM)
 	<-conn.stop
 
-	log.Printf("Shutting down pilad and draining connections with a timeout of %s...", conn.srv.ReadTimeout)
+	shutdownTimeout := conn.Config.ShutdownTimeout() * time.Second
+	log.Printf("Shutting down pilad and draining connections with a timeout of %s...", shutdownTimeout)
 
-	ctx, cancel := context.WithTimeout(context.Background(), conn.srv.ReadTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
 	conn.srv.Shutdown(ctx)

--- a/pilad/server.go
+++ b/pilad/server.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func start(conn *Conn) error {
+	conn.buildConfig()
+	conn.srv = &http.Server{
+		Addr:         fmt.Sprintf(":%d", conn.Config.Port()),
+		Handler:      Router(conn),
+		ReadTimeout:  conn.Config.ReadTimeout() * time.Second,
+		WriteTimeout: conn.Config.WriteTimeout() * time.Second,
+	}
+	logo(conn)
+
+	go listenGracefulShutdown(conn)
+
+	if err := conn.srv.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+	<-conn.idle
+	return nil
+}
+
+func listenGracefulShutdown(conn *Conn) {
+	signal.Notify(conn.stop, os.Interrupt, syscall.SIGTERM)
+	<-conn.stop
+
+	log.Printf("Shutting down pilad and draining connections with a timeout of %s...", conn.srv.ReadTimeout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), conn.srv.ReadTimeout)
+	defer cancel()
+
+	conn.srv.Shutdown(ctx)
+	close(conn.idle)
+	log.Println("Bye!")
+}

--- a/pilad/server_test.go
+++ b/pilad/server_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"net/http"
+	"syscall"
+	"testing"
+)
+
+func TestStart(t *testing.T) {
+	conn := NewConn()
+	conn.stop <- syscall.SIGTERM
+	if err := start(conn); err != nil {
+		t.Errorf("err is %v, expected nil", err)
+	}
+}
+
+func TestListenGracefulShutdown(t *testing.T) {
+	conn := NewConn()
+	conn.srv = &http.Server{}
+
+	go listenGracefulShutdown(conn)
+	conn.stop <- syscall.SIGTERM
+}


### PR DESCRIPTION
Previously, when running a pilad server and then terminating it, it stopped immediately without caring about on-going connections.

With this change, whenever pilad server receives `SIGINT` or `SIGTERM` signals, it will wait for on-going connections until they are finished. If the connections aren't finished after the _Shutdown Timeout_ is due, they all will be interrupted and the shutdown will happen.

This _Shutdown Timeout_ can be configure with the `pilad` command with the `-shutdown-timeout` parameter, which value is 15 seconds by default. As other config values, it can be set on runtime using the `/_config` endpoint.