### PR TITLE
Introduce request for donations on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ All notable changes to this project will be documented in this file.
 - Add `FULL` operation
 - Add `ROTATE` operation
 - Add `BLOCK` and `UNBLOCK` operations
-- Test against Go version 1.10.x to be up-to-date with new releases
+- Add opt-out request for donation on server startup
 
 ### Changed
 - pkg/uuid: Replace md5 with sha1 and be compliant to Version 5 of RFC 4122
 - Update Dependencies section in the README file
+- Test against Go version 1.10.x to be up-to-date with new releases
 
 ## [0.1.5] - 2018-02-23
 

--- a/config/value.go
+++ b/config/value.go
@@ -50,6 +50,13 @@ func (c *Config) Port() int {
 	return t
 }
 
+// NoDonate returns the value of NO_DONATE.
+// Type: bool, Default: false
+func (c *Config) NoDonate() bool {
+	noDonate := c.Get(vars.NoDonate)
+	return boolValue(noDonate, vars.NoDonateDefault)
+}
+
 // PushWhenFull returns the value of PUSH_WHEN_FULL.
 // Type: bool, Default: false
 func (c *Config) PushWhenFull() bool {

--- a/config/value_test.go
+++ b/config/value_test.go
@@ -153,3 +153,28 @@ func TestPushWhenFull(t *testing.T) {
 		}
 	}
 }
+
+func TestNoDonate(t *testing.T) {
+	c := NewConfig()
+
+	inputOutput := []struct {
+		input  interface{}
+		output bool
+	}{
+		{true, true},
+		{false, false},
+		{"true", true},
+		{"false", false},
+		{"foo", vars.NoDonateDefault},
+		{42, vars.NoDonateDefault},
+		{[]byte("true"), vars.NoDonateDefault},
+	}
+
+	for _, io := range inputOutput {
+		c.Set(vars.NoDonate, io.input)
+
+		if s := c.NoDonate(); s != io.output {
+			t.Errorf("NoDonate is %v, expected %v", s, io.output)
+		}
+	}
+}

--- a/config/vars/vars.go
+++ b/config/vars/vars.go
@@ -50,6 +50,13 @@ const (
 	// PushWhenFullDefault represents the default value
 	// of PushWhenFull.
 	PushWhenFullDefault = false
+
+	// NoDonate disables the donation request message
+	// on pilad startup.
+	NoDonate = "NO_DONATE"
+	// NoDonateDefault represents the default value
+	// of NoDonate.
+	NoDonateDefault = false
 )
 
 // Env returns the environment variable name

--- a/config/vars/vars_test.go
+++ b/config/vars/vars_test.go
@@ -37,6 +37,7 @@ func TestDefaultBool(t *testing.T) {
 		output bool
 	}{
 		{PushWhenFull, PushWhenFullDefault},
+		{NoDonate, NoDonateDefault},
 		{"foo", false},
 	}
 

--- a/pilad/config.go
+++ b/pilad/config.go
@@ -20,7 +20,7 @@ var (
 	maxStackSizeFlag                                       int
 	readTimeoutFlag, writeTimeoutFlag, shutdownTimeoutFlag int
 	portFlag                                               int
-	pushWhenFullFlag                                       bool
+	pushWhenFullFlag, noDonateFlag                         bool
 	versionFlag                                            bool
 )
 
@@ -31,6 +31,7 @@ func init() {
 	flag.IntVar(&shutdownTimeoutFlag, "shutdown-timeout", vars.ShutdownTimeoutDefault, "Graceful shutdown timeout")
 	flag.IntVar(&portFlag, "port", vars.PortDefault, "Port number")
 	flag.BoolVar(&pushWhenFullFlag, "push-when-full", vars.PushWhenFullDefault, "Allow push when Stack is full")
+	flag.BoolVar(&noDonateFlag, "no-donate", vars.NoDonateDefault, "Disable donation request on startup")
 	flag.BoolVar(&versionFlag, "v", false, "Version")
 }
 
@@ -49,6 +50,7 @@ func (c *Conn) buildConfig() {
 		{shutdownTimeoutFlag, vars.ShutdownTimeout},
 		{portFlag, vars.Port},
 		{pushWhenFullFlag, vars.PushWhenFull},
+		{noDonateFlag, vars.NoDonate},
 	}
 
 	for _, fk := range flagKeys {

--- a/pilad/logo.go
+++ b/pilad/logo.go
@@ -4,22 +4,25 @@ import "log"
 
 func logo(conn *Conn) {
 	log.Println()
-	log.Println("         d8b 888               888 888      ")
-	log.Println("         Y8P 888               888 888      ")
-	log.Println("             888               888 888      ")
-	log.Println("88888b.  888 888  8888b.   .d88888 88888b.  ")
-	log.Println("888 \"88b 888 888    \"88b  d88\" 888 888 \"88b ")
-	log.Println("888  888 888 888 .d888888 888  888 888  888 ")
-	log.Println("888 d88P 888 888 888  888 Y88b 888 888 d88P ")
-	log.Println("88888P\"  888 888 \"Y888888  \"Y88888 88888P\"  ")
-	log.Println("888")
-	log.Println("888")
-	log.Println("888")
+	log.Println("  .___.            _  _             _  _     ")
+	log.Println(" /  _  \\    _ __  (_)| |  __ _   __| || |__  ")
+	log.Println("|  |+|  |  | '_ \\ | || | / _` | / _` || '_ \\ ")
+	log.Println("|  |-|  |  | |_) || || || (_| || (_| || |_) |")
+	log.Println(" \\.___./   | .__/ |_||_| \\__,_| \\__,_||_.__/ ")
+	log.Println("           |_|                               ")
 	log.Println()
 	log.Printf("Version:      %s", conn.Status.Version)
 	log.Printf("Go Version:   %s", conn.Status.GoVersion)
 	log.Printf("Host:         %s", conn.Status.Host)
 	log.Printf("Port:         %d", conn.Config.Port())
 	log.Printf("PID:          %d", conn.Status.PID)
+	log.Printf("Started at:   %s", conn.Status.StartedAt)
 	log.Println()
+
+	if !conn.Config.NoDonate() {
+		log.Println("If you want to support open source development of piladb")
+		log.Println("please consider making a donation: https://www.paypal.me/oscillatingworks")
+		log.Println("Thanks!")
+		log.Println()
+	}
 }


### PR DESCRIPTION
This can be disabled by using the `-no-donate` command line
flag, or setting `PILADB_NO_DONATE` environment variable to `true`.

This PR also introduces a new ASCII logo for the startup:

```
   .___.            _  _             _  _     
  /  _  \    _ __  (_)| |  __ _   __| || |__  
 |  |+|  |  | '_ \ | || | / _` | / _` || '_ \ 
 |  |-|  |  | |_) || || || (_| || (_| || |_) |
  \.___./   | .__/ |_||_| \__,_| \__,_||_.__/ 
            |_|   
```